### PR TITLE
Use the opaque struct pattern to get types in C.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ CFLAGS := -Werror -Wall -Wextra -Wpedantic
 LDFLAGS := -Wl,--gc-sections -lpthread -ldl
 
 all: target/crustls-demo
+
+test: all
 	target/crustls-demo httpbin.org /headers
 
 target:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,9 @@ type CrustlsResult = c_int;
 pub const CRUSTLS_OK: c_int = 0;
 pub const CRUSTLS_ERROR: c_int = 1;
 
-// We use the opaque struct trick pattern to tell C about our types without
+// We use the opaque struct pattern to tell C about our types without
 // telling them what's inside.
+// https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
 #[allow(non_camel_case_types)]
 pub struct rustls_client_config {
     _private: [u8; 0],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_type = "staticlib"]
-
-use libc::{c_char, c_int, c_void, size_t, ssize_t};
+use libc::{c_char, c_int, size_t, ssize_t};
 use std::io::{Cursor, Read, Write};
 use std::slice;
 use std::{ffi::CStr, sync::Arc};
@@ -13,16 +12,27 @@ type CrustlsResult = c_int;
 pub const CRUSTLS_OK: c_int = 0;
 pub const CRUSTLS_ERROR: c_int = 1;
 
+// We use the opaque struct trick pattern to tell C about our types without
+// telling them what's inside.
+#[allow(non_camel_case_types)]
+pub struct client_config {
+    _private: [u8; 0],
+}
+#[allow(non_camel_case_types)]
+pub struct client_session {
+    _private: [u8; 0],
+}
+
 /// Create a client_config. Caller owns the memory and must free it with
 /// rustls_client_config_free.
 #[no_mangle]
-pub extern "C" fn rustls_client_config_new() -> *const c_void {
+pub extern "C" fn rustls_client_config_new() -> *const client_config {
     let mut config = rustls::ClientConfig::new();
     config
         .root_store
         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     env_logger::init();
-    Arc::into_raw(Arc::new(config)) as *const c_void
+    Arc::into_raw(Arc::new(config)) as *const _
 }
 
 /// "Free" a client_config previously returned from rustls_client_config_new.
@@ -32,7 +42,7 @@ pub extern "C" fn rustls_client_config_new() -> *const c_void {
 /// "free"ing it.
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
-pub extern "C" fn rustls_client_config_free(config: *const c_void) {
+pub extern "C" fn rustls_client_config_free(config: *const client_config) {
     unsafe {
         if let Some(c) = (config as *const ClientConfig).as_ref() {
             // To free the client_config, we reconstruct the Arc. It should have a refcount of 1,
@@ -80,9 +90,9 @@ unsafe fn arc_with_incref_from_raw<T>(v: *const T) -> Arc<T> {
 /// `rustls_client_session_free` when done with it.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_new(
-    config: *const c_void,
+    config: *const client_config,
     hostname: *const c_char,
-    session_out: *mut *mut c_void,
+    session_out: *mut *mut client_session,
 ) -> CrustlsResult {
     let hostname: &CStr = unsafe {
         if hostname.is_null() {
@@ -124,14 +134,14 @@ pub extern "C" fn rustls_client_session_new(
     // caller knows it is responsible for this memory.
     let b = Box::new(client);
     unsafe {
-        *session_out = Box::into_raw(b) as *mut c_void;
+        *session_out = Box::into_raw(b) as *mut _;
     }
 
     return CRUSTLS_OK;
 }
 
 #[no_mangle]
-pub extern "C" fn rustls_client_session_wants_read(session: *const c_void) -> bool {
+pub extern "C" fn rustls_client_session_wants_read(session: *const client_session) -> bool {
     unsafe {
         match (session as *const ClientSession).as_ref() {
             Some(cs) => cs.wants_read(),
@@ -141,7 +151,7 @@ pub extern "C" fn rustls_client_session_wants_read(session: *const c_void) -> bo
 }
 
 #[no_mangle]
-pub extern "C" fn rustls_client_session_wants_write(session: *const c_void) -> bool {
+pub extern "C" fn rustls_client_session_wants_write(session: *const client_session) -> bool {
     unsafe {
         match (session as *const ClientSession).as_ref() {
             Some(cs) => cs.wants_write(),
@@ -151,7 +161,9 @@ pub extern "C" fn rustls_client_session_wants_write(session: *const c_void) -> b
 }
 
 #[no_mangle]
-pub extern "C" fn rustls_client_session_process_new_packets(session: *mut c_void) -> CrustlsResult {
+pub extern "C" fn rustls_client_session_process_new_packets(
+    session: *mut client_session,
+) -> CrustlsResult {
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
@@ -174,7 +186,7 @@ pub extern "C" fn rustls_client_session_process_new_packets(session: *mut c_void
 /// Free a client_session previously returned from rustls_client_session_new.
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
-pub extern "C" fn rustls_client_session_free(session: *mut c_void) {
+pub extern "C" fn rustls_client_session_free(session: *mut client_session) {
     unsafe {
         if let Some(c) = (session as *mut ClientSession).as_mut() {
             // Convert the pointer to a Box and drop it.
@@ -189,7 +201,7 @@ pub extern "C" fn rustls_client_session_free(session: *mut c_void) {
 /// write(2). It returns the number of bytes written, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write(
-    session: *const c_void,
+    session: *const client_session,
     buf: *const u8,
     count: size_t,
 ) -> ssize_t {
@@ -224,7 +236,7 @@ pub extern "C" fn rustls_client_session_write(
 /// the number of bytes read, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read(
-    session: *const c_void,
+    session: *const client_session,
     buf: *mut u8,
     count: size_t,
 ) -> ssize_t {
@@ -271,7 +283,7 @@ pub extern "C" fn rustls_client_session_read(
 /// read(2). It returns the number of bytes read, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read_tls(
-    session: *const c_void,
+    session: *const client_session,
     buf: *const u8,
     count: size_t,
 ) -> ssize_t {
@@ -306,7 +318,7 @@ pub extern "C" fn rustls_client_session_read_tls(
 /// a socket. This acts like write(2). It returns the number of bytes read, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write_tls(
-    session: *const c_void,
+    session: *const client_session,
     buf: *mut u8,
     count: size_t,
 ) -> ssize_t {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,18 +15,18 @@ pub const CRUSTLS_ERROR: c_int = 1;
 // We use the opaque struct trick pattern to tell C about our types without
 // telling them what's inside.
 #[allow(non_camel_case_types)]
-pub struct client_config {
+pub struct rustls_client_config {
     _private: [u8; 0],
 }
 #[allow(non_camel_case_types)]
-pub struct client_session {
+pub struct rustls_client_session {
     _private: [u8; 0],
 }
 
 /// Create a client_config. Caller owns the memory and must free it with
 /// rustls_client_config_free.
 #[no_mangle]
-pub extern "C" fn rustls_client_config_new() -> *const client_config {
+pub extern "C" fn rustls_client_config_new() -> *const rustls_client_config {
     let mut config = rustls::ClientConfig::new();
     config
         .root_store
@@ -42,7 +42,7 @@ pub extern "C" fn rustls_client_config_new() -> *const client_config {
 /// "free"ing it.
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
-pub extern "C" fn rustls_client_config_free(config: *const client_config) {
+pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config) {
     unsafe {
         if let Some(c) = (config as *const ClientConfig).as_ref() {
             // To free the client_config, we reconstruct the Arc. It should have a refcount of 1,
@@ -90,9 +90,9 @@ unsafe fn arc_with_incref_from_raw<T>(v: *const T) -> Arc<T> {
 /// `rustls_client_session_free` when done with it.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_new(
-    config: *const client_config,
+    config: *const rustls_client_config,
     hostname: *const c_char,
-    session_out: *mut *mut client_session,
+    session_out: *mut *mut rustls_client_session,
 ) -> CrustlsResult {
     let hostname: &CStr = unsafe {
         if hostname.is_null() {
@@ -141,7 +141,7 @@ pub extern "C" fn rustls_client_session_new(
 }
 
 #[no_mangle]
-pub extern "C" fn rustls_client_session_wants_read(session: *const client_session) -> bool {
+pub extern "C" fn rustls_client_session_wants_read(session: *const rustls_client_session) -> bool {
     unsafe {
         match (session as *const ClientSession).as_ref() {
             Some(cs) => cs.wants_read(),
@@ -151,7 +151,7 @@ pub extern "C" fn rustls_client_session_wants_read(session: *const client_sessio
 }
 
 #[no_mangle]
-pub extern "C" fn rustls_client_session_wants_write(session: *const client_session) -> bool {
+pub extern "C" fn rustls_client_session_wants_write(session: *const rustls_client_session) -> bool {
     unsafe {
         match (session as *const ClientSession).as_ref() {
             Some(cs) => cs.wants_write(),
@@ -162,7 +162,7 @@ pub extern "C" fn rustls_client_session_wants_write(session: *const client_sessi
 
 #[no_mangle]
 pub extern "C" fn rustls_client_session_process_new_packets(
-    session: *mut client_session,
+    session: *mut rustls_client_session,
 ) -> CrustlsResult {
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
@@ -186,7 +186,7 @@ pub extern "C" fn rustls_client_session_process_new_packets(
 /// Free a client_session previously returned from rustls_client_session_new.
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
-pub extern "C" fn rustls_client_session_free(session: *mut client_session) {
+pub extern "C" fn rustls_client_session_free(session: *mut rustls_client_session) {
     unsafe {
         if let Some(c) = (session as *mut ClientSession).as_mut() {
             // Convert the pointer to a Box and drop it.
@@ -201,7 +201,7 @@ pub extern "C" fn rustls_client_session_free(session: *mut client_session) {
 /// write(2). It returns the number of bytes written, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write(
-    session: *const client_session,
+    session: *const rustls_client_session,
     buf: *const u8,
     count: size_t,
 ) -> ssize_t {
@@ -236,7 +236,7 @@ pub extern "C" fn rustls_client_session_write(
 /// the number of bytes read, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read(
-    session: *const client_session,
+    session: *const rustls_client_session,
     buf: *mut u8,
     count: size_t,
 ) -> ssize_t {
@@ -283,7 +283,7 @@ pub extern "C" fn rustls_client_session_read(
 /// read(2). It returns the number of bytes read, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read_tls(
-    session: *const client_session,
+    session: *const rustls_client_session,
     buf: *const u8,
     count: size_t,
 ) -> ssize_t {
@@ -318,7 +318,7 @@ pub extern "C" fn rustls_client_session_read_tls(
 /// a socket. This acts like write(2). It returns the number of bytes read, or -1 on error.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write_tls(
-    session: *const client_session,
+    session: *const rustls_client_session,
     buf: *mut u8,
     count: size_t,
 ) -> ssize_t {

--- a/src/main.c
+++ b/src/main.c
@@ -86,7 +86,8 @@ cleanup:
  * the message and return 1.
  */
 int
-send_request_and_read_response(int sockfd, rustls_client_session *client_session,
+send_request_and_read_response(int sockfd,
+                               struct rustls_client_session *client_session,
                                const char *hostname, const char *path)
 {
   int ret = 1;
@@ -229,7 +230,8 @@ cleanup:
 }
 
 int
-do_request(const rustls_client_config *client_config, const char *hostname, const char *path)
+do_request(const struct rustls_client_config *client_config,
+           const char *hostname, const char *path)
 {
   int ret = 1;
   int sockfd = make_conn(hostname);
@@ -238,7 +240,7 @@ do_request(const rustls_client_config *client_config, const char *hostname, cons
     goto cleanup;
   }
 
-  rustls_client_session *client_session = NULL;
+  struct rustls_client_session *client_session = NULL;
   int result =
     rustls_client_session_new(client_config, hostname, &client_session);
   if(result != CRUSTLS_OK) {
@@ -276,7 +278,8 @@ main(int argc, const char **argv)
   const char *hostname = argv[1];
   const char *path = argv[2];
 
-  const rustls_client_config *client_config = rustls_client_config_new();
+  const struct rustls_client_config *client_config =
+    rustls_client_config_new();
 
   int i;
   for(i = 0; i < 3; i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -86,7 +86,7 @@ cleanup:
  * the message and return 1.
  */
 int
-send_request_and_read_response(int sockfd, void *client_session,
+send_request_and_read_response(int sockfd, client_session *client_session,
                                const char *hostname, const char *path)
 {
   int ret = 1;
@@ -229,7 +229,7 @@ cleanup:
 }
 
 int
-do_request(const void *client_config, const char *hostname, const char *path)
+do_request(const client_config *client_config, const char *hostname, const char *path)
 {
   int ret = 1;
   int sockfd = make_conn(hostname);
@@ -238,7 +238,7 @@ do_request(const void *client_config, const char *hostname, const char *path)
     goto cleanup;
   }
 
-  void *client_session = NULL;
+  client_session *client_session = NULL;
   int result =
     rustls_client_session_new(client_config, hostname, &client_session);
   if(result != CRUSTLS_OK) {
@@ -276,7 +276,7 @@ main(int argc, const char **argv)
   const char *hostname = argv[1];
   const char *path = argv[2];
 
-  const void *client_config = rustls_client_config_new();
+  const client_config *client_config = rustls_client_config_new();
 
   int i;
   for(i = 0; i < 3; i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -86,7 +86,7 @@ cleanup:
  * the message and return 1.
  */
 int
-send_request_and_read_response(int sockfd, client_session *client_session,
+send_request_and_read_response(int sockfd, rustls_client_session *client_session,
                                const char *hostname, const char *path)
 {
   int ret = 1;
@@ -229,7 +229,7 @@ cleanup:
 }
 
 int
-do_request(const client_config *client_config, const char *hostname, const char *path)
+do_request(const rustls_client_config *client_config, const char *hostname, const char *path)
 {
   int ret = 1;
   int sockfd = make_conn(hostname);
@@ -238,7 +238,7 @@ do_request(const client_config *client_config, const char *hostname, const char 
     goto cleanup;
   }
 
-  client_session *client_session = NULL;
+  rustls_client_session *client_session = NULL;
   int result =
     rustls_client_session_new(client_config, hostname, &client_session);
   if(result != CRUSTLS_OK) {
@@ -276,7 +276,7 @@ main(int argc, const char **argv)
   const char *hostname = argv[1];
   const char *path = argv[2];
 
-  const client_config *client_config = rustls_client_config_new();
+  const rustls_client_config *client_config = rustls_client_config_new();
 
   int i;
   for(i = 0; i < 3; i++) {


### PR DESCRIPTION
Now the C code can use `*client_config` and `*client_session`, and will
get errors if it mixes them up.