### PR TITLE
Add rustls_version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ description = "C-to-rustls bindings"
 edition = "2018"
 
 [dependencies]
-rustls = "0.19"
+# Keep in sync with RUSTLS_CRATE_VERSION in lib.rs
+rustls = "^0.19.0"
 webpki = "0.21"
 libc = "0.2"
 env_logger = "0.8"


### PR DESCRIPTION
I chose a "caller provides memory" style of output because that is how the corresponding `version` hook in curl handles things.