### PR TITLE
Use output parameters for n, and add conventions to README.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ webpki = "0.21"
 libc = "0.2"
 env_logger = "0.8"
 webpki-roots = "0.21"
+sct = "0.6.0"
 
 [dev_dependencies]
 cbindgen = "*"

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ test: all
 target:
 	mkdir -p $@
 
-src/crustls.h: src/lib.rs
+src/crustls.h: src/lib.rs src/error.rs
 	cbindgen --lang C > $@
 
 target/crustls-demo: target/main.o target/$(PROFILE)/libcrustls.a
 	$(CC) -o $@ $^ $(LDFLAGS)
 
-target/$(PROFILE)/libcrustls.a: src/lib.rs Cargo.toml
+target/$(PROFILE)/libcrustls.a: src/lib.rs src/error.rs Cargo.toml
 	cargo build $(CARGOFLAGS)
 
 target/main.o: src/main.c src/crustls.h | target

--- a/README.md
+++ b/README.md
@@ -19,3 +19,85 @@ To install:
 To build and install in optimized mode:
 
     make PROFILE=release install
+
+# Conventions
+
+This library defines an enum, rustls_result, to indicate success or failure of
+a function call. All fallible functions return a rustls_result. If a function
+has other outputs, it provides them using output parameters (pointers to
+caller-provided objects). For instance:
+
+```rust
+rustls_result rustls_client_session_read(const rustls_client_session *session,
+                                         uint8_t *buf,
+                                         size_t count,
+                                         size_t *out_n);
+```
+
+In this example, `buf` and `out_n` are output parameters.
+
+## Structs
+
+For a given struct, all functions that start with the name of that struct are
+either associated functions or methods of that struct. For instance,
+`rustls_client_session_read` is a method of `rustls_client_session`. A function
+that takes a pointer to a struct as the first parameter is considered a method
+on that struct. Structs in this library are always created and destroyed by
+library code, so the header file only gives a declaration of the structs, not
+a definition.
+
+As a result, structs are always handled using pointers. For each struct, there
+is generally a function ending in `_new()` to create that struct. Once you've
+got a pointer to a struct, it's your responsibility to (a) ensure no two
+threads are concurrently mutating that struct, and (b) free that struct's
+memory exactly once. Freeing a struct's memory will usually be accomplished
+with a function starting with the struct's name and ending in `_free()`.
+
+You can tell if a method will mutate a struct by looking at the first
+parameter. If it's a `const*`, the method is non-mutating. Otherwise, it's 
+mutating.
+
+## Input and Output Parameters
+
+Input parameters will always be either a const pointer or a primitive type
+(int, size_t, etc). Output parameters will always be a non-const pointer.
+
+The caller is responsible for ensuring that the memory pointed to be output
+parameters is not being concurrently accessed by other threads. For primitive
+types and pointers-to-pointers this is most commonly accomplished by passing
+the address of a local variable on the stack that has no references elsewhere.
+For buffers, stack allocation is also a simple way to accomplish this, but if
+the buffer is allocated on heap and references to it are shared among threads,
+the caller will need to take additional steps to prevent concurrent access
+(for instance mutex locking, or single-threaded I/O).
+
+When an output parameter is a pointer to a pointer (e.g. 
+`rustls_client_session **session_out`, the function will set its argument
+to point to an appropriate object on success. The caller is considered to take
+ownership of that object and be responsible for the requirements above:
+preventing concurrent mutation, and freeing it exactly once.
+
+For a method, the first parameter will always be a pointer to the struct being
+operated on. Next will come some number of input parameters, then some number
+of output parameters. 
+
+As a minor exception to the above: When an output parameter is a byte buffer
+(*uint8_t), the next parameter will always be a size_t denoting the size of
+the buffer. This is considered part of the output parameters even though it is
+not directly modified.
+
+There are no in/out parameters. When an output buffer is passed, the library
+only writes to that buffer and does not read from it.
+
+For fallible functions, values are only written to the output arguments if
+the function returns success. There are no partial successes or partial
+failures. Callers must check the return value before relying on the values
+pointed to by output arguments.
+
+## NULL
+
+The library checks all pointers in arguments for NULL and will return an error
+rather than dereferencing a NULL pointer. For some methods that are infallible
+except for the possibility of NULL (for instance
+`rustls_client_session_is_handshaking`), the library returns a convenient
+type (e.g. `bool`) and uses a suitable fallback value if an input is NULL.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,358 @@
+use std::{cmp::min, fmt::Display, slice};
+
+use libc::{c_char, size_t};
+use rustls::TLSError;
+
+/// After a rustls_client_session method returns an error, you may call
+/// this method to get a pointer to a buffer containing a detailed error
+/// message. The contents of the error buffer will be out_n bytes long,
+/// UTF-8 encoded, and not NUL-terminated.
+#[no_mangle]
+pub extern "C" fn rustls_error(
+    result: rustls_result,
+    buf: *mut c_char,
+    len: size_t,
+    out_n: *mut size_t,
+) {
+    let write_buf: &mut [u8] = unsafe {
+        let out_n: &mut size_t = match out_n.as_mut() {
+            Some(out_n) => out_n,
+            None => return,
+        };
+        *out_n = 0;
+        if buf.is_null() {
+            return;
+        }
+        slice::from_raw_parts_mut(buf as *mut u8, len as usize)
+    };
+    let error_str = result.to_string();
+    let len: usize = min(write_buf.len() - 1, error_str.len());
+    write_buf[..len].copy_from_slice(&error_str.as_bytes()[..len]);
+    unsafe {
+        *out_n = len;
+    }
+}
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub enum rustls_result {
+    Ok = 7000,
+    Io,
+    NullParameter,
+
+    // From https://docs.rs/rustls/0.19.0/rustls/enum.TLSError.html
+    CorruptMessage,
+    NoCertificatesPresented,
+    DecryptError,
+    FailedToGetCurrentTime,
+    HandshakeNotComplete,
+    PeerSentOversizedRecord,
+    NoApplicationProtocol,
+
+    // From TLSError, with fields that get dropped.
+    PeerIncompatibleError,
+    PeerMisbehavedError,
+    InappropriateMessage,
+    InappropriateHandshakeMessage,
+    CorruptMessagePayload,
+    General,
+
+    // From TLSError, with fields that get flattened.
+    // https://docs.rs/rustls/0.19.0/rustls/internal/msgs/enums/enum.AlertDescription.html
+    AlertCloseNotify,
+    AlertUnexpectedMessage,
+    AlertBadRecordMac,
+    AlertDecryptionFailed,
+    AlertRecordOverflow,
+    AlertDecompressionFailure,
+    AlertHandshakeFailure,
+    AlertNoCertificate,
+    AlertBadCertificate,
+    AlertUnsupportedCertificate,
+    AlertCertificateRevoked,
+    AlertCertificateExpired,
+    AlertCertificateUnknown,
+    AlertIllegalParameter,
+    AlertUnknownCA,
+    AlertAccessDenied,
+    AlertDecodeError,
+    AlertDecryptError,
+    AlertExportRestriction,
+    AlertProtocolVersion,
+    AlertInsufficientSecurity,
+    AlertInternalError,
+    AlertInappropriateFallback,
+    AlertUserCanceled,
+    AlertNoRenegotiation,
+    AlertMissingExtension,
+    AlertUnsupportedExtension,
+    AlertCertificateUnobtainable,
+    AlertUnrecognisedName,
+    AlertBadCertificateStatusResponse,
+    AlertBadCertificateHashValue,
+    AlertUnknownPSKIdentity,
+    AlertCertificateRequired,
+    AlertNoApplicationProtocol,
+    AlertUnknown,
+
+    // https://docs.rs/webpki/0.21.4/webpki/enum.Error.html
+    CertBadDER,
+    CertBadDERTime,
+    CertCAUsedAsEndEntity,
+    CertExpired,
+    CertNotValidForName,
+    CertNotValidYet,
+    CertEndEntityUsedAsCA,
+    CertExtensionValueInvalid,
+    CertInvalidCertValidity,
+    CertInvalidSignatureForPublicKey,
+    CertNameConstraintViolation,
+    CertPathLenConstraintViolated,
+    CertSignatureAlgorithmMismatch,
+    CertRequiredEKUNotFound,
+    CertUnknownIssuer,
+    CertUnsupportedCertVersion,
+    CertUnsupportedCriticalExtension,
+    CertUnsupportedSignatureAlgorithmForPublicKey,
+    CertUnsupportedSignatureAlgorithm,
+
+    // https://docs.rs/sct/0.5.0/sct/enum.Error.html
+    CertSCTMalformed,
+    CertSCTInvalidSignature,
+    CertSCTTimestampInFuture,
+    CertSCTUnsupportedVersion,
+    CertSCTUnknownLog,
+}
+
+pub(crate) fn map_error(input: rustls::TLSError) -> rustls_result {
+    use rustls::internal::msgs::enums::AlertDescription as alert;
+    use rustls_result::*;
+    use sct::Error as sct;
+    use webpki::Error as webpki;
+
+    match input {
+        TLSError::CorruptMessage => CorruptMessage,
+        TLSError::NoCertificatesPresented => NoCertificatesPresented,
+        TLSError::DecryptError => DecryptError,
+        TLSError::FailedToGetCurrentTime => FailedToGetCurrentTime,
+        TLSError::HandshakeNotComplete => HandshakeNotComplete,
+        TLSError::PeerSentOversizedRecord => PeerSentOversizedRecord,
+        TLSError::NoApplicationProtocol => NoApplicationProtocol,
+
+        TLSError::PeerIncompatibleError(_) => PeerIncompatibleError,
+        TLSError::PeerMisbehavedError(_) => PeerMisbehavedError,
+        TLSError::General(_) => General,
+        TLSError::InappropriateMessage { .. } => InappropriateMessage,
+        TLSError::InappropriateHandshakeMessage { .. } => InappropriateHandshakeMessage,
+        TLSError::CorruptMessagePayload(_) => CorruptMessagePayload,
+
+        TLSError::AlertReceived(e) => match e {
+            alert::CloseNotify => AlertCloseNotify,
+            alert::UnexpectedMessage => AlertUnexpectedMessage,
+            alert::BadRecordMac => AlertBadRecordMac,
+            alert::DecryptionFailed => AlertDecryptionFailed,
+            alert::RecordOverflow => AlertRecordOverflow,
+            alert::DecompressionFailure => AlertDecompressionFailure,
+            alert::HandshakeFailure => AlertHandshakeFailure,
+            alert::NoCertificate => AlertNoCertificate,
+            alert::BadCertificate => AlertBadCertificate,
+            alert::UnsupportedCertificate => AlertUnsupportedCertificate,
+            alert::CertificateRevoked => AlertCertificateRevoked,
+            alert::CertificateExpired => AlertCertificateExpired,
+            alert::CertificateUnknown => AlertCertificateUnknown,
+            alert::IllegalParameter => AlertIllegalParameter,
+            alert::UnknownCA => AlertUnknownCA,
+            alert::AccessDenied => AlertAccessDenied,
+            alert::DecodeError => AlertDecodeError,
+            alert::DecryptError => AlertDecryptError,
+            alert::ExportRestriction => AlertExportRestriction,
+            alert::ProtocolVersion => AlertProtocolVersion,
+            alert::InsufficientSecurity => AlertInsufficientSecurity,
+            alert::InternalError => AlertInternalError,
+            alert::InappropriateFallback => AlertInappropriateFallback,
+            alert::UserCanceled => AlertUserCanceled,
+            alert::NoRenegotiation => AlertNoRenegotiation,
+            alert::MissingExtension => AlertMissingExtension,
+            alert::UnsupportedExtension => AlertUnsupportedExtension,
+            alert::CertificateUnobtainable => AlertCertificateUnobtainable,
+            alert::UnrecognisedName => AlertUnrecognisedName,
+            alert::BadCertificateStatusResponse => AlertBadCertificateStatusResponse,
+            alert::BadCertificateHashValue => AlertBadCertificateHashValue,
+            alert::UnknownPSKIdentity => AlertUnknownPSKIdentity,
+            alert::CertificateRequired => AlertCertificateRequired,
+            alert::NoApplicationProtocol => AlertNoApplicationProtocol,
+            alert::Unknown(_) => AlertUnknown,
+        },
+        TLSError::WebPKIError(e) => match e {
+            webpki::BadDER => CertBadDER,
+            webpki::BadDERTime => CertBadDERTime,
+            webpki::CAUsedAsEndEntity => CertCAUsedAsEndEntity,
+            webpki::CertExpired => CertExpired,
+            webpki::CertNotValidForName => CertNotValidForName,
+            webpki::CertNotValidYet => CertNotValidYet,
+            webpki::EndEntityUsedAsCA => CertEndEntityUsedAsCA,
+            webpki::ExtensionValueInvalid => CertExtensionValueInvalid,
+            webpki::InvalidCertValidity => CertInvalidCertValidity,
+            webpki::InvalidSignatureForPublicKey => CertInvalidSignatureForPublicKey,
+            webpki::NameConstraintViolation => CertNameConstraintViolation,
+            webpki::PathLenConstraintViolated => CertPathLenConstraintViolated,
+            webpki::SignatureAlgorithmMismatch => CertSignatureAlgorithmMismatch,
+            webpki::RequiredEKUNotFound => CertRequiredEKUNotFound,
+            webpki::UnknownIssuer => CertUnknownIssuer,
+            webpki::UnsupportedCertVersion => CertUnsupportedCertVersion,
+            webpki::UnsupportedCriticalExtension => CertUnsupportedCriticalExtension,
+            webpki::UnsupportedSignatureAlgorithmForPublicKey => {
+                CertUnsupportedSignatureAlgorithmForPublicKey
+            }
+            webpki::UnsupportedSignatureAlgorithm => CertUnsupportedSignatureAlgorithm,
+        },
+        TLSError::InvalidSCT(e) => match e {
+            sct::MalformedSCT => CertSCTMalformed,
+            sct::InvalidSignature => CertSCTInvalidSignature,
+            sct::TimestampInFuture => CertSCTTimestampInFuture,
+            sct::UnsupportedSCTVersion => CertSCTUnsupportedVersion,
+            sct::UnknownLog => CertSCTUnknownLog,
+        },
+    }
+}
+
+impl Display for rustls_result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", result_to_string(self))
+    }
+}
+
+fn result_to_string(input: &rustls_result) -> String {
+    use rustls::internal::msgs::enums::AlertDescription as alert;
+    use rustls_result::*;
+    use sct::Error as sct;
+    use webpki::Error as webpki;
+
+    let msg = match input {
+        // These variants are local to this glue layer.
+        rustls_result::Ok => "OK".to_string(),
+        Io => "I/O error".to_string(),
+        NullParameter => "a parameter was NULL".to_string(),
+
+        // These variants correspond to a TLSError variant with a field,
+        // where generating an arbitrary field would produce a confusing error
+        // message. So we reproduce a simplified error string.
+        InappropriateMessage => "received unexpected message".to_string(),
+        InappropriateHandshakeMessage => "received unexpected handshake message".to_string(),
+        CorruptMessagePayload => "received corrupt message".to_string(),
+
+        CorruptMessage => TLSError::CorruptMessage.to_string(),
+        NoCertificatesPresented => TLSError::NoCertificatesPresented.to_string(),
+        DecryptError => TLSError::DecryptError.to_string(),
+        FailedToGetCurrentTime => TLSError::FailedToGetCurrentTime.to_string(),
+        HandshakeNotComplete => TLSError::HandshakeNotComplete.to_string(),
+        PeerSentOversizedRecord => TLSError::PeerSentOversizedRecord.to_string(),
+        NoApplicationProtocol => TLSError::NoApplicationProtocol.to_string(),
+        PeerIncompatibleError => {
+            TLSError::PeerIncompatibleError("reason omitted".to_string()).to_string()
+        }
+        PeerMisbehavedError => {
+            TLSError::PeerMisbehavedError("reason omitted".to_string()).to_string()
+        }
+        General => TLSError::General("omitted".to_string()).to_string(),
+
+        AlertCloseNotify => TLSError::AlertReceived(alert::CloseNotify).to_string(),
+        AlertUnexpectedMessage => TLSError::AlertReceived(alert::UnexpectedMessage).to_string(),
+        AlertBadRecordMac => TLSError::AlertReceived(alert::BadRecordMac).to_string(),
+        AlertDecryptionFailed => TLSError::AlertReceived(alert::DecryptionFailed).to_string(),
+        AlertRecordOverflow => TLSError::AlertReceived(alert::RecordOverflow).to_string(),
+        AlertDecompressionFailure => {
+            TLSError::AlertReceived(alert::DecompressionFailure).to_string()
+        }
+        AlertHandshakeFailure => TLSError::AlertReceived(alert::HandshakeFailure).to_string(),
+        AlertNoCertificate => TLSError::AlertReceived(alert::NoCertificate).to_string(),
+        AlertBadCertificate => TLSError::AlertReceived(alert::BadCertificate).to_string(),
+        AlertUnsupportedCertificate => {
+            TLSError::AlertReceived(alert::UnsupportedCertificate).to_string()
+        }
+        AlertCertificateRevoked => TLSError::AlertReceived(alert::CertificateRevoked).to_string(),
+        AlertCertificateExpired => TLSError::AlertReceived(alert::CertificateExpired).to_string(),
+        AlertCertificateUnknown => TLSError::AlertReceived(alert::CertificateUnknown).to_string(),
+        AlertIllegalParameter => TLSError::AlertReceived(alert::IllegalParameter).to_string(),
+        AlertUnknownCA => TLSError::AlertReceived(alert::UnknownCA).to_string(),
+        AlertAccessDenied => TLSError::AlertReceived(alert::AccessDenied).to_string(),
+        AlertDecodeError => TLSError::AlertReceived(alert::DecodeError).to_string(),
+        AlertDecryptError => TLSError::AlertReceived(alert::DecryptError).to_string(),
+        AlertExportRestriction => TLSError::AlertReceived(alert::ExportRestriction).to_string(),
+        AlertProtocolVersion => TLSError::AlertReceived(alert::ProtocolVersion).to_string(),
+        AlertInsufficientSecurity => {
+            TLSError::AlertReceived(alert::InsufficientSecurity).to_string()
+        }
+        AlertInternalError => TLSError::AlertReceived(alert::InternalError).to_string(),
+        AlertInappropriateFallback => {
+            TLSError::AlertReceived(alert::InappropriateFallback).to_string()
+        }
+        AlertUserCanceled => TLSError::AlertReceived(alert::UserCanceled).to_string(),
+        AlertNoRenegotiation => TLSError::AlertReceived(alert::NoRenegotiation).to_string(),
+        AlertMissingExtension => TLSError::AlertReceived(alert::MissingExtension).to_string(),
+        AlertUnsupportedExtension => {
+            TLSError::AlertReceived(alert::UnsupportedExtension).to_string()
+        }
+        AlertCertificateUnobtainable => {
+            TLSError::AlertReceived(alert::CertificateUnobtainable).to_string()
+        }
+        AlertUnrecognisedName => TLSError::AlertReceived(alert::UnrecognisedName).to_string(),
+        AlertBadCertificateStatusResponse => {
+            TLSError::AlertReceived(alert::BadCertificateStatusResponse).to_string()
+        }
+        AlertBadCertificateHashValue => {
+            TLSError::AlertReceived(alert::BadCertificateHashValue).to_string()
+        }
+        AlertUnknownPSKIdentity => TLSError::AlertReceived(alert::UnknownPSKIdentity).to_string(),
+        AlertCertificateRequired => TLSError::AlertReceived(alert::CertificateRequired).to_string(),
+        AlertNoApplicationProtocol => {
+            TLSError::AlertReceived(alert::NoApplicationProtocol).to_string()
+        }
+        AlertUnknown => TLSError::AlertReceived(alert::Unknown(0)).to_string(),
+
+        CertBadDER => TLSError::WebPKIError(webpki::BadDER).to_string(),
+        CertBadDERTime => TLSError::WebPKIError(webpki::BadDERTime).to_string(),
+        CertCAUsedAsEndEntity => TLSError::WebPKIError(webpki::CAUsedAsEndEntity).to_string(),
+        CertExpired => TLSError::WebPKIError(webpki::CertExpired).to_string(),
+        CertNotValidForName => TLSError::WebPKIError(webpki::CertNotValidForName).to_string(),
+        CertNotValidYet => TLSError::WebPKIError(webpki::CertNotValidYet).to_string(),
+        CertEndEntityUsedAsCA => TLSError::WebPKIError(webpki::EndEntityUsedAsCA).to_string(),
+        CertExtensionValueInvalid => {
+            TLSError::WebPKIError(webpki::ExtensionValueInvalid).to_string()
+        }
+        CertInvalidCertValidity => TLSError::WebPKIError(webpki::InvalidCertValidity).to_string(),
+        CertInvalidSignatureForPublicKey => {
+            TLSError::WebPKIError(webpki::InvalidSignatureForPublicKey).to_string()
+        }
+        CertNameConstraintViolation => {
+            TLSError::WebPKIError(webpki::NameConstraintViolation).to_string()
+        }
+        CertPathLenConstraintViolated => {
+            TLSError::WebPKIError(webpki::PathLenConstraintViolated).to_string()
+        }
+        CertSignatureAlgorithmMismatch => {
+            TLSError::WebPKIError(webpki::SignatureAlgorithmMismatch).to_string()
+        }
+        CertRequiredEKUNotFound => TLSError::WebPKIError(webpki::RequiredEKUNotFound).to_string(),
+        CertUnknownIssuer => TLSError::WebPKIError(webpki::UnknownIssuer).to_string(),
+        CertUnsupportedCertVersion => {
+            TLSError::WebPKIError(webpki::UnsupportedCertVersion).to_string()
+        }
+        CertUnsupportedCriticalExtension => {
+            TLSError::WebPKIError(webpki::UnsupportedCriticalExtension).to_string()
+        }
+        CertUnsupportedSignatureAlgorithmForPublicKey => {
+            TLSError::WebPKIError(webpki::UnsupportedSignatureAlgorithmForPublicKey).to_string()
+        }
+        CertUnsupportedSignatureAlgorithm => {
+            TLSError::WebPKIError(webpki::UnsupportedSignatureAlgorithm).to_string()
+        }
+
+        CertSCTMalformed => TLSError::InvalidSCT(sct::MalformedSCT).to_string(),
+        CertSCTInvalidSignature => TLSError::InvalidSCT(sct::InvalidSignature).to_string(),
+        CertSCTTimestampInFuture => TLSError::InvalidSCT(sct::TimestampInFuture).to_string(),
+        CertSCTUnsupportedVersion => TLSError::InvalidSCT(sct::UnsupportedSCTVersion).to_string(),
+        CertSCTUnknownLog => TLSError::InvalidSCT(sct::UnknownLog).to_string(),
+    };
+    format!("rustls: {}", msg)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,9 @@ use std::{io::ErrorKind::ConnectionAborted, mem};
 
 use rustls::{ClientConfig, ClientSession, Session};
 
-#[allow(non_camel_case_types)]
-#[repr(C)]
-pub enum rustls_result {
-    OK = 0,
-    ERROR = 1,
-}
+mod error;
+use error::{map_error, rustls_result};
+use rustls_result::NullParameter;
 
 // We use the opaque struct pattern to tell C about our types without
 // telling them what's inside.
@@ -39,7 +36,6 @@ const RUSTLS_CRATE_VERSION: &str = "0.19.0";
 pub extern "C" fn rustls_version(buf: *mut c_char, len: size_t) -> size_t {
     let write_buf: &mut [u8] = unsafe {
         if buf.is_null() {
-            eprintln!("rustls_version: buf was NULL!");
             return 0;
         }
         slice::from_raw_parts_mut(buf as *mut u8, len as usize)
@@ -129,25 +125,21 @@ pub extern "C" fn rustls_client_session_new(
 ) -> rustls_result {
     let hostname: &CStr = unsafe {
         if hostname.is_null() {
-            eprintln!("rustls_client_session_new: hostname was NULL");
-            return rustls_result::ERROR;
+            return NullParameter;
         }
         CStr::from_ptr(hostname)
     };
     let config: Arc<ClientConfig> = unsafe {
         match (config as *const ClientConfig).as_ref() {
             Some(c) => arc_with_incref_from_raw(c),
-            None => {
-                eprintln!("rustls_client_session_new: config was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let hostname: &str = match hostname.to_str() {
         Ok(s) => s,
         Err(e) => {
             eprintln!("converting hostname to Rust &str: {}", e);
-            return rustls_result::ERROR;
+            return rustls_result::Io;
         }
     };
     let name_ref = match webpki::DNSNameRef::try_from_ascii_str(hostname) {
@@ -157,7 +149,7 @@ pub extern "C" fn rustls_client_session_new(
                 "turning hostname '{}' into webpki::DNSNameRef: {}",
                 hostname, e
             );
-            return rustls_result::ERROR;
+            return rustls_result::Io;
         }
     };
     let client = ClientSession::new(&config, name_ref);
@@ -170,7 +162,7 @@ pub extern "C" fn rustls_client_session_new(
         *session_out = Box::into_raw(b) as *mut _;
     }
 
-    return rustls_result::OK;
+    return rustls_result::Ok;
 }
 
 #[no_mangle]
@@ -212,18 +204,12 @@ pub extern "C" fn rustls_client_session_process_new_packets(
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
-            None => {
-                eprintln!("ClientSession::process_new_packets: session was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     match session.process_new_packets() {
-        Ok(()) => rustls_result::OK,
-        Err(e) => {
-            eprintln!("ClientSession::process_new_packets: {}", e);
-            return rustls_result::ERROR;
-        }
+        Ok(()) => rustls_result::Ok,
+        Err(e) => return map_error(e),
     }
 }
 
@@ -257,37 +243,27 @@ pub extern "C" fn rustls_client_session_write(
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
-            None => {
-                eprintln!("ClientSession::write: session was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let write_buf: &[u8] = unsafe {
         if buf.is_null() {
-            eprintln!("ClientSession::write: buf was NULL");
-            return rustls_result::ERROR;
+            return NullParameter;
         }
         slice::from_raw_parts(buf, count as usize)
     };
     let out_n: &mut size_t = unsafe {
         match out_n.as_mut() {
             Some(out_n) => out_n,
-            None => {
-                eprintln!("ClientSession::write: out_n was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let n_written: usize = match session.write(write_buf) {
         Ok(n) => n,
-        Err(e) => {
-            eprintln!("ClientSession::write: {}", e);
-            return rustls_result::ERROR;
-        }
+        Err(_) => return rustls_result::Io,
     };
     *out_n = n_written;
-    rustls_result::OK
+    rustls_result::Ok
 }
 
 /// Read up to `count` plaintext bytes from the ClientSession into `buf`.
@@ -307,26 +283,19 @@ pub extern "C" fn rustls_client_session_read(
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
-            None => {
-                eprintln!("ClientSession::read: session was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let read_buf: &mut [u8] = unsafe {
         if buf.is_null() {
-            eprintln!("ClientSession::read: buf was NULL");
-            return rustls_result::ERROR;
+            return NullParameter;
         }
         slice::from_raw_parts_mut(buf, count as usize)
     };
     let out_n = unsafe {
         match out_n.as_mut() {
             Some(out_n) => out_n,
-            None => {
-                eprintln!("ClientSession::read: out_n was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     // Since it's *possible* for a Read impl to consume the possibly-uninitialized memory from buf,
@@ -341,17 +310,13 @@ pub extern "C" fn rustls_client_session_read(
         // https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#impl-Read.
         // Log it and return EOF.
         Err(e) if e.kind() == ConnectionAborted && e.to_string().contains("CloseNotify") => {
-            eprintln!("ClientSession::read: CloseNotify (this is expected): {}", e);
             *out_n = 0;
-            return rustls_result::OK;
+            return rustls_result::Ok;
         }
-        Err(e) => {
-            eprintln!("ClientSession::read: {}", e);
-            return rustls_result::ERROR;
-        }
+        Err(_) => return rustls_result::Io,
     };
     *out_n = n_read;
-    rustls_result::OK
+    rustls_result::Ok
 }
 
 /// Read up to `count` TLS bytes from `buf` (usually read from a socket) into
@@ -372,38 +337,28 @@ pub extern "C" fn rustls_client_session_read_tls(
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
-            None => {
-                eprintln!("ClientSession::read_tls: session was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let input_buf: &[u8] = unsafe {
         if buf.is_null() {
-            eprintln!("ClientSession::read_tls: buf was NULL");
-            return rustls_result::ERROR;
+            return NullParameter;
         }
         slice::from_raw_parts(buf, count as usize)
     };
     let out_n = unsafe {
         match out_n.as_mut() {
             Some(out_n) => out_n,
-            None => {
-                eprintln!("ClientSession::read_tls: out_n was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let mut cursor = Cursor::new(input_buf);
     let n_read: usize = match session.read_tls(&mut cursor) {
         Ok(n) => n,
-        Err(e) => {
-            eprintln!("ClientSession::read_tls: {}", e);
-            return rustls_result::ERROR;
-        }
+        Err(_) => return rustls_result::Io,
     };
     *out_n = n_read;
-    rustls_result::OK
+    rustls_result::Ok
 }
 
 /// Write up to `count` TLS bytes from the ClientSession into `buf`. Those
@@ -420,35 +375,25 @@ pub extern "C" fn rustls_client_session_write_tls(
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
-            None => {
-                eprintln!("ClientSession::write_tls: session was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let mut output_buf: &mut [u8] = unsafe {
         if buf.is_null() {
-            eprintln!("ClientSession::write_tls: buf was NULL");
-            return rustls_result::ERROR;
+            return NullParameter;
         }
         slice::from_raw_parts_mut(buf, count as usize)
     };
     let out_n = unsafe {
         match out_n.as_mut() {
             Some(out_n) => out_n,
-            None => {
-                eprintln!("ClientSession::write_tls: out_n was NULL");
-                return rustls_result::ERROR;
-            }
+            None => return NullParameter,
         }
     };
     let n_written: usize = match session.write_tls(&mut output_buf) {
         Ok(n) => n,
-        Err(e) => {
-            eprintln!("ClientSession::write_tls: {}", e);
-            return rustls_result::ERROR;
-        }
+        Err(_) => return rustls_result::Io,
     };
     *out_n = n_written;
-    rustls_result::OK
+    rustls_result::Ok
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![crate_type = "staticlib"]
-use libc::{c_char, size_t, ssize_t};
+use libc::{c_char, size_t};
 use std::slice;
 use std::{
     cmp::min,
@@ -241,64 +241,93 @@ pub extern "C" fn rustls_client_session_free(session: *mut rustls_client_session
     }
 }
 
-/// Write plaintext bytes into the ClientSession. This acts like
-/// write(2). It returns the number of bytes written, or -1 on error.
+/// Write up to `count` plaintext bytes from `buf` into the ClientSession.
+/// This will increase the number of output bytes available to
+/// `rustls_client_session_write_tls`.
+/// On success, store the number of bytes actually written in *out_n
+/// (this may be less than `count`).
+/// https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.write
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write(
     session: *const rustls_client_session,
     buf: *const u8,
     count: size_t,
-) -> ssize_t {
+    out_n: *mut size_t,
+) -> rustls_result {
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
             None => {
                 eprintln!("ClientSession::write: session was NULL");
-                return -1;
+                return rustls_result::ERROR;
             }
         }
     };
     let write_buf: &[u8] = unsafe {
         if buf.is_null() {
             eprintln!("ClientSession::write: buf was NULL");
-            return -1;
+            return rustls_result::ERROR;
         }
         slice::from_raw_parts(buf, count as usize)
+    };
+    let out_n: &mut size_t = unsafe {
+        match out_n.as_mut() {
+            Some(out_n) => out_n,
+            None => {
+                eprintln!("ClientSession::write: out_n was NULL");
+                return rustls_result::ERROR;
+            }
+        }
     };
     let n_written: usize = match session.write(write_buf) {
         Ok(n) => n,
         Err(e) => {
             eprintln!("ClientSession::write: {}", e);
-            return -1;
+            return rustls_result::ERROR;
         }
     };
-    n_written as ssize_t
+    *out_n = n_written;
+    rustls_result::OK
 }
 
-/// Read plaintext bytes from the ClientSession. This acts like
-/// read(2), writing the plaintext bytes into `buf`. It returns
-/// the number of bytes read, or -1 on error.
+/// Read up to `count` plaintext bytes from the ClientSession into `buf`.
+/// On success, store the number of bytes read in *out_n (this may be less
+/// than `count`). A success with *out_n set to 0 means "all bytes currently
+/// available have been read, but more bytes may become available after
+/// subsequent calls to rustls_client_session_read_tls and
+/// rustls_client_session_process_new_packets."
+/// https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.read
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read(
     session: *const rustls_client_session,
     buf: *mut u8,
     count: size_t,
-) -> ssize_t {
+    out_n: *mut size_t,
+) -> rustls_result {
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
             None => {
                 eprintln!("ClientSession::read: session was NULL");
-                return -1;
+                return rustls_result::ERROR;
             }
         }
     };
     let read_buf: &mut [u8] = unsafe {
         if buf.is_null() {
             eprintln!("ClientSession::read: buf was NULL");
-            return -1;
+            return rustls_result::ERROR;
         }
         slice::from_raw_parts_mut(buf, count as usize)
+    };
+    let out_n = unsafe {
+        match out_n.as_mut() {
+            Some(out_n) => out_n,
+            None => {
+                eprintln!("ClientSession::read: out_n was NULL");
+                return rustls_result::ERROR;
+            }
+        }
     };
     // Since it's *possible* for a Read impl to consume the possibly-uninitialized memory from buf,
     // zero it out just in case. TODO: use Initializer once it's stabilized.
@@ -313,81 +342,113 @@ pub extern "C" fn rustls_client_session_read(
         // Log it and return EOF.
         Err(e) if e.kind() == ConnectionAborted && e.to_string().contains("CloseNotify") => {
             eprintln!("ClientSession::read: CloseNotify (this is expected): {}", e);
-            return 0;
+            *out_n = 0;
+            return rustls_result::OK;
         }
         Err(e) => {
             eprintln!("ClientSession::read: {}", e);
-            return -1;
+            return rustls_result::ERROR;
         }
     };
-    n_read as ssize_t
+    *out_n = n_read;
+    rustls_result::OK
 }
 
-/// Read TLS bytes taken from a socket into the ClientSession. This acts like
-/// read(2). It returns the number of bytes read, or -1 on error.
+/// Read up to `count` TLS bytes from `buf` (usually read from a socket) into
+/// the ClientSession. This may make packets available to
+/// `rustls_client_session_process_new_packets`, which in turn may make more
+/// bytes available to `rustls_client_session_read`.
+/// On success, store the number of bytes actually read in *out_n (this may
+/// be less than `count`). This function returns success and stores 0 in
+/// *out_n when the input count is 0.
+/// https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.read_tls
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read_tls(
     session: *const rustls_client_session,
     buf: *const u8,
     count: size_t,
-) -> ssize_t {
+    out_n: *mut size_t,
+) -> rustls_result {
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
             None => {
                 eprintln!("ClientSession::read_tls: session was NULL");
-                return -1;
+                return rustls_result::ERROR;
             }
         }
     };
     let input_buf: &[u8] = unsafe {
         if buf.is_null() {
             eprintln!("ClientSession::read_tls: buf was NULL");
-            return -1;
+            return rustls_result::ERROR;
         }
         slice::from_raw_parts(buf, count as usize)
+    };
+    let out_n = unsafe {
+        match out_n.as_mut() {
+            Some(out_n) => out_n,
+            None => {
+                eprintln!("ClientSession::read_tls: out_n was NULL");
+                return rustls_result::ERROR;
+            }
+        }
     };
     let mut cursor = Cursor::new(input_buf);
     let n_read: usize = match session.read_tls(&mut cursor) {
         Ok(n) => n,
         Err(e) => {
             eprintln!("ClientSession::read_tls: {}", e);
-            return -1;
+            return rustls_result::ERROR;
         }
     };
-    n_read as ssize_t
+    *out_n = n_read;
+    rustls_result::OK
 }
 
-/// Write TLS bytes from the ClientSession into a buffer. Those bytes should then be written to
-/// a socket. This acts like write(2). It returns the number of bytes read, or -1 on error.
+/// Write up to `count` TLS bytes from the ClientSession into `buf`. Those
+/// bytes should then be written to a socket. On success, store the number of
+/// bytes actually written in *out_n (this maybe less than `count`).
+/// https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write_tls(
     session: *const rustls_client_session,
     buf: *mut u8,
     count: size_t,
-) -> ssize_t {
+    out_n: *mut size_t,
+) -> rustls_result {
     let session: &mut ClientSession = unsafe {
         match (session as *mut ClientSession).as_mut() {
             Some(cs) => cs,
             None => {
                 eprintln!("ClientSession::write_tls: session was NULL");
-                return -1;
+                return rustls_result::ERROR;
             }
         }
     };
     let mut output_buf: &mut [u8] = unsafe {
         if buf.is_null() {
             eprintln!("ClientSession::write_tls: buf was NULL");
-            return -1;
+            return rustls_result::ERROR;
         }
         slice::from_raw_parts_mut(buf, count as usize)
+    };
+    let out_n = unsafe {
+        match out_n.as_mut() {
+            Some(out_n) => out_n,
+            None => {
+                eprintln!("ClientSession::write_tls: out_n was NULL");
+                return rustls_result::ERROR;
+            }
+        }
     };
     let n_written: usize = match session.write_tls(&mut output_buf) {
         Ok(n) => n,
         Err(e) => {
             eprintln!("ClientSession::write_tls: {}", e);
-            return -1;
+            return rustls_result::ERROR;
         }
     };
-    n_written as ssize_t
+    *out_n = n_written;
+    rustls_result::OK
 }

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,15 @@ enum crustls_demo_result
   CRUSTLS_DEMO_EOF,
 };
 
+void
+print_error(char *prefix, rustls_result result)
+{
+  char buf[256];
+  size_t n;
+  rustls_error(result, buf, sizeof(buf), &n);
+  fprintf(stderr, "%s: %.*s\n", prefix, (int)n, buf);
+}
+
 /*
  * Write n bytes from buf to the provided fd, retrying short writes until
  * we finish or hit an error. Assumes fd is blocking and therefore doesn't
@@ -148,7 +157,7 @@ copy_tls_bytes_into_client_session(
 
     result = rustls_client_session_process_new_packets(client_session);
     if(result != RUSTLS_RESULT_OK) {
-      fprintf(stderr, "Error in process_new_packets\n");
+      print_error("in process_new_packets", result);
       goto fail;
     }
   }
@@ -169,7 +178,7 @@ fail:
 int
 copy_plaintext_to_stdout(struct rustls_client_session *client_session)
 {
-  int result = RUSTLS_RESULT_ERROR;
+  int result;
   char buf[2048];
   size_t n;
 

--- a/src/main.c
+++ b/src/main.c
@@ -122,35 +122,42 @@ cleanup:
  */
 int
 copy_tls_bytes_into_client_session(
-  struct rustls_client_session *client_session, uint8_t *buf, size_t len)
+  struct rustls_client_session *client_session, uint8_t *buf, size_t len,
+  size_t *out_n)
 {
-  ssize_t n;
+  size_t n;
+  size_t n_written = 0;
   int result;
 
-  while(len > 0) {
-    n = rustls_client_session_read_tls(client_session, buf, len);
-    if(n == 0) {
-      fprintf(stderr, "EOF from ClientSession::read_tls %ld \n", len);
-      return 1;
-    }
-    else if(n < 0) {
+  while(n_written < len) {
+    result = rustls_client_session_read_tls(
+      client_session, buf + n_written, len - n_written, &n);
+    if(result != RUSTLS_RESULT_OK) {
       fprintf(stderr, "Error in ClientSession::read_tls\n");
-      return 1;
+      goto fail;
     }
-    if((size_t)n > len) {
+    if(n == 0) {
+      fprintf(stderr, "EOF from ClientSession::read_tls\n");
+      goto fail;
+    }
+    if(n > len) {
       fprintf(stderr, "too many bytes written to ClientSession; overflow\n");
-      return 1;
+      goto fail;
     }
-    len -= n;
-    buf += n;
+    n_written += n;
 
     result = rustls_client_session_process_new_packets(client_session);
     if(result != RUSTLS_RESULT_OK) {
       fprintf(stderr, "Error in process_new_packets\n");
-      return 1;
+      goto fail;
     }
   }
+  *out_n = n_written;
   return 0;
+
+fail:
+  *out_n = n_written;
+  return 1;
 }
 
 /* Read all available bytes from the client_session until EOF.
@@ -162,21 +169,21 @@ copy_tls_bytes_into_client_session(
 int
 copy_plaintext_to_stdout(struct rustls_client_session *client_session)
 {
-  int result = 1;
+  int result = RUSTLS_RESULT_ERROR;
   char buf[2048];
-  int n;
+  size_t n;
 
   for(;;) {
     bzero(buf, sizeof(buf));
-    n =
-      rustls_client_session_read(client_session, (uint8_t *)buf, sizeof(buf));
+    result = rustls_client_session_read(
+      client_session, (uint8_t *)buf, sizeof(buf), &n);
+    if(result != RUSTLS_RESULT_OK) {
+      fprintf(stderr, "Error in ClientSession::read\n");
+      return 1;
+    }
     if(n == 0) {
       /* EOF from ClientSession::read. This is expected. */
       return 0;
-    }
-    else if(n < 0) {
-      fprintf(stderr, "Error in ClientSession::read\n");
-      return 1;
     }
 
     result = write_all(STDOUT_FILENO, buf, n);
@@ -204,6 +211,8 @@ do_read(int sockfd, struct rustls_client_session *client_session)
 {
   int result = 1;
   ssize_t n = 0;
+  size_t buflen = 0;
+  size_t n_from_rustls = 0;
   char buf[2048];
 
   bzero(buf, sizeof(buf));
@@ -224,6 +233,7 @@ do_read(int sockfd, struct rustls_client_session *client_session)
       return CRUSTLS_DEMO_ERROR;
     }
   }
+  buflen = (size_t)n;
 
   /*
    * Now pull those bytes from the buffer into ClientSession.
@@ -231,8 +241,8 @@ do_read(int sockfd, struct rustls_client_session *client_session)
    * want to pull in unitialized memory that we didn't just
    * read from the socket.
    */
-  result =
-    copy_tls_bytes_into_client_session(client_session, (uint8_t *)buf, n);
+  result = copy_tls_bytes_into_client_session(
+    client_session, (uint8_t *)buf, buflen, &n_from_rustls);
   if(result != 0) {
     return CRUSTLS_DEMO_ERROR;
   }
@@ -260,7 +270,7 @@ send_request_and_read_response(int sockfd,
   char buf[2048];
   fd_set read_fds;
   fd_set write_fds;
-  int n = 0;
+  size_t n = 0;
 
   bzero(buf, sizeof(buf));
   snprintf(buf,
@@ -273,9 +283,14 @@ send_request_and_read_response(int sockfd,
            "\r\n",
            path,
            hostname);
-  n = rustls_client_session_write(client_session, (uint8_t *)buf, strlen(buf));
-  if(n < 0) {
+  result = rustls_client_session_write(
+    client_session, (uint8_t *)buf, strlen(buf), &n);
+  if(result != RUSTLS_RESULT_OK) {
     fprintf(stderr, "error writing plaintext bytes to ClientSession\n");
+    goto cleanup;
+  }
+  if(n != strlen(buf)) {
+    fprintf(stderr, "short write writing plaintext bytes to ClientSession\n");
     goto cleanup;
   }
 
@@ -317,14 +332,14 @@ send_request_and_read_response(int sockfd,
        FD_ISSET(sockfd, &write_fds)) {
       fprintf(stderr, "ClientSession wants us to write_tls.\n");
       bzero(buf, sizeof(buf));
-      n = rustls_client_session_write_tls(
-        client_session, (uint8_t *)buf, sizeof(buf));
-      if(n == 0) {
-        fprintf(stderr, "EOF from ClientSession::write_tls\n");
+      result = rustls_client_session_write_tls(
+        client_session, (uint8_t *)buf, sizeof(buf), &n);
+      if(result != RUSTLS_RESULT_OK) {
+        fprintf(stderr, "Error in ClientSession::write_tls\n");
         goto cleanup;
       }
-      else if(n < 0) {
-        fprintf(stderr, "Error in ClientSession::write_tls\n");
+      else if(n == 0) {
+        fprintf(stderr, "EOF from ClientSession::write_tls\n");
         goto cleanup;
       }
 


### PR DESCRIPTION
This documents some details of how the library is designed and how to
interact with it. In particular it sets a new convention: If a function
or method is fallible, it returns rustls_result. The resulted in a
change to the four read/write functions. Previously they acted like
`read(2)`/`write(2)`, returning an ssize_t. Now, they return a
`rustls_result` and store the number of bytes read/written in an output
argument.

Corresponding changes to my PR branch against curl:
https://github.com/jsha/curl/pull/1. I'll merge that into the branch under
review once this PR lands, so that PR branch will continue to build
successfully against master.