### PR TITLE
Add configuration of trusted roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crustls"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 description = "C-to-rustls bindings"
 edition = "2018"
@@ -11,7 +11,7 @@ rustls = "^0.19.0"
 webpki = "0.21"
 libc = "0.2"
 env_logger = "0.8"
-webpki-roots = "0.21"
+rustls-native-certs = "0.5.0"
 
 [dev_dependencies]
 cbindgen = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,15 @@ pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config)
             // To free the client_config, we reconstruct the Arc. It should have a refcount of 1,
             // representing the C code's copy. When it drops, that refcount will go down to 0
             // and the inner ClientConfig will be dropped.
-            drop(Arc::from_raw(c));
+            let arc: Arc<ClientConfig> = Arc::from_raw(c);
+            let strong_count = Arc::strong_count(&arc);
+            if strong_count < 1 {
+                eprintln!(
+                    "rustls_client_config_free: invariant failed: arc.strong_count was < 1: {}. \
+                    You must not free the same client_config multiple times.",
+                    strong_count
+                );
+            }
         } else {
             eprintln!("rustls_client_config_free: config was NULL");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@ pub extern "C" fn rustls_client_config_builder_new() -> *mut rustls_client_confi
     Box::into_raw(b) as *mut _
 }
 
+/// Turn a *rustls_client_config_builder (mutable) into a *rustls_client_config
+/// (read-only).
 #[no_mangle]
 pub extern "C" fn rustls_client_config_builder_build(
     builder: *mut rustls_client_config_builder,

--- a/src/main.c
+++ b/src/main.c
@@ -417,8 +417,16 @@ main(int argc, const char **argv)
   const char *hostname = argv[1];
   const char *path = argv[2];
 
-  const struct rustls_client_config *client_config =
-    rustls_client_config_new();
+  struct rustls_client_config_builder *config_builder =
+    rustls_client_config_builder_new();
+  const struct rustls_client_config *client_config = NULL;
+
+  result = rustls_client_config_builder_load_native_roots(config_builder);
+  if(result != RUSTLS_RESULT_OK) {
+    fprintf(stderr, "error loading trusted certificates\n");
+  }
+
+  client_config = rustls_client_config_builder_build(config_builder);
 
   int i;
   for(i = 0; i < 3; i++) {


### PR DESCRIPTION
This removes the dependency on the webpki-roots crate, which bundles a set of trusted roots, in favor of the rustls-native-roots crate, which provides a way to trust the roots installed in the OS.

This also creates a new type alias `rustls_client_config_builder`, to represent the state of a ClientConfig that may still be mutated (for instance by adding trusted roots to the default, empty, set). Once the user has set up the config as desired, a builder is turned into a `rustls_client_config`, which is not mutable.

