### PR TITLE
Remove env_logger.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 rustls = "^0.19.0"
 webpki = "0.21"
 libc = "0.2"
-env_logger = "0.8"
 rustls-native-certs = "0.5.0"
 sct = "0.6.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,6 @@ pub extern "C" fn rustls_version(buf: *mut c_char, len: size_t) -> size_t {
 #[no_mangle]
 pub extern "C" fn rustls_client_config_builder_new() -> *mut rustls_client_config_builder {
     let config = rustls::ClientConfig::new();
-    env_logger::init();
     let b = Box::new(config);
     Box::into_raw(b) as *mut _
 }
@@ -223,13 +222,11 @@ pub extern "C" fn rustls_client_session_new(
     };
     let hostname: &str = match hostname.to_str() {
         Ok(s) => s,
-        Err(std::str::Utf8Error{..}) =>
-         return rustls_result::InvalidDnsNameError,
+        Err(std::str::Utf8Error { .. }) => return rustls_result::InvalidDnsNameError,
     };
     let name_ref = match webpki::DNSNameRef::try_from_ascii_str(hostname) {
         Ok(nr) => nr,
-        Err(webpki::InvalidDNSNameError{..}) =>
-         return rustls_result::InvalidDnsNameError,
+        Err(webpki::InvalidDNSNameError { .. }) => return rustls_result::InvalidDnsNameError,
     };
     let client = ClientSession::new(&config, name_ref);
 


### PR DESCRIPTION
We can't init env logger twice (causes a panic), and we don't want to
introduce global state to init it only once. We'll add back in some
logging facilities later.

Related to https://github.com/curl/curl/pull/6350#issuecomment-760524529.