### PR TITLE
Make better use of macros.

### DIFF
--- a/src/crustls.h
+++ b/src/crustls.h
@@ -190,7 +190,7 @@ void rustls_client_session_free(rustls_client_session *session);
  * (this may be less than `count`).
  * https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.write
  */
-rustls_result rustls_client_session_write(const rustls_client_session *session,
+rustls_result rustls_client_session_write(rustls_client_session *session,
                                           const uint8_t *buf,
                                           size_t count,
                                           size_t *out_n);
@@ -204,7 +204,7 @@ rustls_result rustls_client_session_write(const rustls_client_session *session,
  * rustls_client_session_process_new_packets."
  * https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.read
  */
-rustls_result rustls_client_session_read(const rustls_client_session *session,
+rustls_result rustls_client_session_read(rustls_client_session *session,
                                          uint8_t *buf,
                                          size_t count,
                                          size_t *out_n);
@@ -219,7 +219,7 @@ rustls_result rustls_client_session_read(const rustls_client_session *session,
  * *out_n when the input count is 0.
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.read_tls
  */
-rustls_result rustls_client_session_read_tls(const rustls_client_session *session,
+rustls_result rustls_client_session_read_tls(rustls_client_session *session,
                                              const uint8_t *buf,
                                              size_t count,
                                              size_t *out_n);
@@ -230,7 +230,7 @@ rustls_result rustls_client_session_read_tls(const rustls_client_session *sessio
  * bytes actually written in *out_n (this maybe less than `count`).
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
  */
-rustls_result rustls_client_session_write_tls(const rustls_client_session *session,
+rustls_result rustls_client_session_write_tls(rustls_client_session *session,
                                               uint8_t *buf,
                                               size_t count,
                                               size_t *out_n);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::{cmp::min, fmt::Display, slice};
 
-use crate::ffi_panic_boundary_unit;
+use crate::{ffi_panic_boundary_generic, ffi_panic_boundary_unit};
 use libc::{c_char, size_t};
 use rustls::TLSError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,12 +106,7 @@ macro_rules! ffi_panic_boundary_unit {
 #[macro_export]
 macro_rules! checked_ptr_ref {
     ( $var:ident, $typ:ty ) => {
-        unsafe {
-            match ($var as *mut $typ).as_ref() {
-                Some(c) => c,
-                None => return rustls_result::NullParameter,
-            }
-        };
+        checked_ptr_ref!($var, $typ, rustls_result::NullParameter)
     };
     ( $var:ident, $typ:ty, $retval:expr ) => {
         unsafe {
@@ -127,12 +122,7 @@ macro_rules! checked_ptr_ref {
 #[macro_export]
 macro_rules! checked_ptr_mut {
     ( $var:ident, $typ:ty ) => {
-        unsafe {
-            match ($var as *mut $typ).as_mut() {
-                Some(c) => c,
-                None => return rustls_result::NullParameter,
-            }
-        };
+        checked_ptr_mut!($var, $typ, rustls_result::NullParameter)
     };
     ( $var:ident, $typ:ty, $retval:expr ) => {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![crate_type = "staticlib"]
 use libc::{c_char, size_t};
-use std::cmp::min;
 use std::io::{BufReader, Cursor, Read, Write};
 use std::slice;
+use std::{cmp::min, ptr::null};
 use std::{ffi::CStr, sync::Arc};
 use std::{ffi::OsStr, fs::File};
 use std::{io::ErrorKind::ConnectionAborted, mem};
@@ -48,6 +48,18 @@ pub struct rustls_client_session {
 const RUSTLS_CRATE_VERSION: &str = "0.19.0";
 
 #[macro_export]
+macro_rules! ffi_panic_boundary_generic {
+    ( $retval:expr, $($tt:tt)* ) => {
+        match ::std::panic::catch_unwind(|| {
+            $($tt)*
+        }) {
+            Ok(ret) => ret,
+            Err(_) => return $retval,
+        }
+    }
+}
+
+#[macro_export]
 macro_rules! ffi_panic_boundary {
     ( $($tt:tt)* ) => {
         match ::std::panic::catch_unwind(|| {
@@ -62,49 +74,74 @@ macro_rules! ffi_panic_boundary {
 #[macro_export]
 macro_rules! ffi_panic_boundary_size_t {
     ( $($tt:tt)* ) => {
-        match ::std::panic::catch_unwind(|| {
-            $($tt)*
-        }) {
-            | Ok(ret) => ret,
-            | Err(_) => return 0,
-        }
-  }
+        ffi_panic_boundary_generic!(0, $($tt)*)
+    }
 }
 
 #[macro_export]
 macro_rules! ffi_panic_boundary_bool {
     ( $($tt:tt)* ) => {
-        match ::std::panic::catch_unwind(|| {
-            $($tt)*
-        }) {
-            | Ok(ret) => ret,
-            | Err(_) => return false,
-        }
-  }
+        ffi_panic_boundary_generic!(false, $($tt)*)
+    }
 }
 
 #[macro_export]
 macro_rules! ffi_panic_boundary_ptr {
     ( $($tt:tt)* ) => {
-        match ::std::panic::catch_unwind(|| {
-            $($tt)*
-        }) {
-            | Ok(ret) => ret,
-            | Err(_) => return std::ptr::null_mut(),
-        }
-  }
+        ffi_panic_boundary_generic!(std::ptr::null_mut(), $($tt)*)
+    }
 }
 
 #[macro_export]
 macro_rules! ffi_panic_boundary_unit {
     ( $($tt:tt)* ) => {
-        match ::std::panic::catch_unwind(|| {
-            $($tt)*
-        }) {
-            | Ok(ret) => ret,
-            | Err(_) => return,
-        }
-  }
+        ffi_panic_boundary_generic!((), $($tt)*)
+    }
+}
+
+/// If the provided pointer is non-null, convert it to a reference
+/// to the type in the second argument.
+/// Otherwise, return NullParameter (in the two-argument form) or the provided
+/// value (in the three-argument form).
+#[macro_export]
+macro_rules! checked_ptr_ref {
+    ( $var:ident, $typ:ty ) => {
+        unsafe {
+            match ($var as *mut $typ).as_ref() {
+                Some(c) => c,
+                None => return rustls_result::NullParameter,
+            }
+        };
+    };
+    ( $var:ident, $typ:ty, $retval:expr ) => {
+        unsafe {
+            match ($var as *mut $typ).as_ref() {
+                Some(c) => c,
+                None => return $retval,
+            }
+        };
+    };
+}
+
+/// Like checked_ptr, but provides mutable references.
+#[macro_export]
+macro_rules! checked_ptr_mut {
+    ( $var:ident, $typ:ty ) => {
+        unsafe {
+            match ($var as *mut $typ).as_mut() {
+                Some(c) => c,
+                None => return rustls_result::NullParameter,
+            }
+        };
+    };
+    ( $var:ident, $typ:ty, $retval:expr ) => {
+        unsafe {
+            match ($var as *mut $typ).as_mut() {
+                Some(c) => c,
+                None => return $retval,
+            }
+        };
+    };
 }
 
 /// Write the version of the crustls C bindings and rustls itself into the
@@ -153,7 +190,9 @@ pub extern "C" fn rustls_client_config_builder_build(
     builder: *mut rustls_client_config_builder,
 ) -> *const rustls_client_config {
     ffi_panic_boundary_ptr! {
-        let b = unsafe { Box::from_raw(builder as *mut ClientConfig) };
+        let config: &mut ClientConfig = checked_ptr_mut!(builder, ClientConfig,
+             null::<rustls_client_config>());
+        let b = unsafe { Box::from_raw(config) };
         Arc::into_raw(Arc::new(*b)) as *const _
     }
 }
@@ -165,12 +204,7 @@ pub extern "C" fn rustls_client_config_builder_load_native_roots(
     config: *mut rustls_client_config_builder,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let mut config: &mut ClientConfig = unsafe {
-            match (config as *mut ClientConfig).as_mut() {
-                Some(c) => c,
-                None => return rustls_result::NullParameter,
-            }
-        };
+        let mut config = checked_ptr_mut!(config, ClientConfig);
         let store = match rustls_native_certs::load_native_certs() {
             Ok(store) => store,
             Err(_) => return rustls_result::Io,
@@ -194,12 +228,7 @@ pub extern "C" fn rustls_client_config_builder_load_roots_from_file(
             }
             CStr::from_ptr(filename)
         };
-        let config: &mut ClientConfig = unsafe {
-            match (config as *mut ClientConfig).as_mut() {
-                Some(c) => c,
-                None => return rustls_result::NullParameter,
-            }
-        };
+        let config: &mut ClientConfig = checked_ptr_mut!(config, ClientConfig);
         let filename: &[u8] = filename.to_bytes();
         let filename: &str = match std::str::from_utf8(filename) {
             Ok(s) => s,
@@ -228,24 +257,19 @@ pub extern "C" fn rustls_client_config_builder_load_roots_from_file(
 #[no_mangle]
 pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config) {
     ffi_panic_boundary_unit! {
-        unsafe {
-            if let Some(c) = (config as *const ClientConfig).as_ref() {
-                // To free the client_config, we reconstruct the Arc. It should have a refcount of 1,
-                // representing the C code's copy. When it drops, that refcount will go down to 0
-                // and the inner ClientConfig will be dropped.
-                let arc: Arc<ClientConfig> = Arc::from_raw(c);
-                let strong_count = Arc::strong_count(&arc);
-                if strong_count < 1 {
-                    eprintln!(
-                        "rustls_client_config_free: invariant failed: arc.strong_count was < 1: {}. \
-                        You must not free the same client_config multiple times.",
-                        strong_count
-                    );
-                }
-            } else {
-                eprintln!("rustls_client_config_free: config was NULL");
-            }
-        };
+        let config: &ClientConfig = checked_ptr_ref!(config, ClientConfig, ());
+        // To free the client_config, we reconstruct the Arc. It should have a refcount of 1,
+        // representing the C code's copy. When it drops, that refcount will go down to 0
+        // and the inner ClientConfig will be dropped.
+        let arc: Arc<ClientConfig> = unsafe { Arc::from_raw(config) };
+        let strong_count = Arc::strong_count(&arc);
+        if strong_count < 1 {
+            eprintln!(
+                "rustls_client_config_free: invariant failed: arc.strong_count was < 1: {}. \
+                You must not free the same client_config multiple times.",
+                strong_count
+            );
+        }
     }
 }
 
@@ -318,24 +342,16 @@ pub extern "C" fn rustls_client_session_new(
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_read(session: *const rustls_client_session) -> bool {
     ffi_panic_boundary_bool! {
-        unsafe {
-            match (session as *const ClientSession).as_ref() {
-                Some(cs) => cs.wants_read(),
-                None => false,
-            }
-        }
+        let session: &ClientSession = checked_ptr_ref!(session, ClientSession, false);
+        session.wants_read()
     }
 }
 
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_write(session: *const rustls_client_session) -> bool {
     ffi_panic_boundary_bool! {
-        unsafe {
-            match (session as *const ClientSession).as_ref() {
-                Some(cs) => cs.wants_write(),
-                None => false,
-            }
-        }
+        let session: &ClientSession = checked_ptr_ref!(session, ClientSession, false);
+        session.wants_write()
     }
 }
 
@@ -344,12 +360,8 @@ pub extern "C" fn rustls_client_session_is_handshaking(
     session: *const rustls_client_session,
 ) -> bool {
     ffi_panic_boundary_bool! {
-        unsafe {
-            match (session as *const ClientSession).as_ref() {
-                Some(cs) => cs.is_handshaking(),
-                None => false,
-            }
-        }
+        let session: & ClientSession = checked_ptr_ref!(session, ClientSession, false);
+        session.is_handshaking()
     }
 }
 
@@ -358,12 +370,7 @@ pub extern "C" fn rustls_client_session_process_new_packets(
     session: *mut rustls_client_session,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = unsafe {
-            match (session as *mut ClientSession).as_mut() {
-                Some(cs) => cs,
-                None => return NullParameter,
-            }
-        };
+        let session: &mut ClientSession = checked_ptr_mut!(session, ClientSession);
         match session.process_new_packets() {
             Ok(()) => rustls_result::Ok,
             Err(e) => return map_error(e),
@@ -376,12 +383,7 @@ pub extern "C" fn rustls_client_session_process_new_packets(
 #[no_mangle]
 pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_client_session) {
     ffi_panic_boundary_unit! {
-        let session: &mut ClientSession = unsafe {
-            match (session as *mut ClientSession).as_mut() {
-                Some(cs) => cs,
-                None => return,
-            }
-        };
+        let session: &mut ClientSession = checked_ptr_mut!(session, ClientSession, ());
         session.send_close_notify()
     }
 }
@@ -391,14 +393,9 @@ pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_c
 #[no_mangle]
 pub extern "C" fn rustls_client_session_free(session: *mut rustls_client_session) {
     ffi_panic_boundary_unit! {
-        unsafe {
-            if let Some(c) = (session as *mut ClientSession).as_mut() {
-                // Convert the pointer to a Box and drop it.
-                Box::from_raw(c);
-            } else {
-                eprintln!("warning: rustls_client_config_free: config was NULL");
-            }
-        }
+        let session: &mut ClientSession = checked_ptr_mut!(session, ClientSession, ());
+        // Convert the pointer to a Box and drop it.
+        unsafe { Box::from_raw(session); }
     }
 }
 
@@ -410,18 +407,13 @@ pub extern "C" fn rustls_client_session_free(session: *mut rustls_client_session
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.write
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write(
-    session: *const rustls_client_session,
+    session: *mut rustls_client_session,
     buf: *const u8,
     count: size_t,
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = unsafe {
-            match (session as *mut ClientSession).as_mut() {
-                Some(cs) => cs,
-                None => return NullParameter,
-            }
-        };
+        let session: &mut ClientSession = checked_ptr_mut!(session, ClientSession);
         let write_buf: &[u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
@@ -452,18 +444,13 @@ pub extern "C" fn rustls_client_session_write(
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.read
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read(
-    session: *const rustls_client_session,
+    session: *mut rustls_client_session,
     buf: *mut u8,
     count: size_t,
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = unsafe {
-            match (session as *mut ClientSession).as_mut() {
-                Some(cs) => cs,
-                None => return NullParameter,
-            }
-        };
+        let session: &mut ClientSession = checked_ptr_mut!(session, ClientSession);
         let read_buf: &mut [u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
@@ -508,18 +495,13 @@ pub extern "C" fn rustls_client_session_read(
 /// https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.read_tls
 #[no_mangle]
 pub extern "C" fn rustls_client_session_read_tls(
-    session: *const rustls_client_session,
+    session: *mut rustls_client_session,
     buf: *const u8,
     count: size_t,
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = unsafe {
-            match (session as *mut ClientSession).as_mut() {
-                Some(cs) => cs,
-                None => return NullParameter,
-            }
-        };
+        let session: &mut ClientSession = checked_ptr_mut!(session, ClientSession);
         let input_buf: &[u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
@@ -548,18 +530,13 @@ pub extern "C" fn rustls_client_session_read_tls(
 /// https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
 #[no_mangle]
 pub extern "C" fn rustls_client_session_write_tls(
-    session: *const rustls_client_session,
+    session: *mut rustls_client_session,
     buf: *mut u8,
     count: size_t,
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = unsafe {
-            match (session as *mut ClientSession).as_mut() {
-                Some(cs) => cs,
-                None => return NullParameter,
-            }
-        };
+        let session: &mut ClientSession = checked_ptr_mut!(session, ClientSession);
         let mut output_buf: &mut [u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ macro_rules! checked_ptr_ref {
     };
     ( $var:ident, $typ:ty, $retval:expr ) => {
         unsafe {
-            match ($var as *mut $typ).as_ref() {
+            match ($var as *const $typ).as_ref() {
                 Some(c) => c,
                 None => return $retval,
             }
@@ -194,7 +194,7 @@ pub extern "C" fn rustls_client_config_builder_load_native_roots(
     config: *mut rustls_client_config_builder,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let mut config = checked_ptr_mut!(config, ClientConfig);
+        let mut config: &mut ClientConfig = checked_ptr_mut!(config, ClientConfig);
         let store = match rustls_native_certs::load_native_certs() {
             Ok(store) => store,
             Err(_) => return rustls_result::Io,
@@ -350,7 +350,7 @@ pub extern "C" fn rustls_client_session_is_handshaking(
     session: *const rustls_client_session,
 ) -> bool {
     ffi_panic_boundary_bool! {
-        let session: & ClientSession = checked_ptr_ref!(session, ClientSession, false);
+        let session: &ClientSession = checked_ptr_ref!(session, ClientSession, false);
         session.is_handshaking()
     }
 }


### PR DESCRIPTION
Add checked_ptr_ref! and checked_ptr_mut! to eliminate the
repeated null-pointer checking code we had at the beginning of each
function.

Revise the ffi_panic_boundary_* macros to be implemented in terms of
ffi_panic_boundary_generic!, which takes a return value as an argument.

Remove some `const` modifiers on parameters that are actually treated
as mutable (rustls_client_session_read, rustls_client_session_write,
etc).

I think overall this improves clarity by removing boilerplate. For instance
the wants_read and is_handshaking methods are much more clearly
plain passthroughs now. But feel free to tell me "you're getting carried
away with macros!"