### PR TITLE
fix GitHub action YAML

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: make test
       - run: make PROFILE=release test
-
-jobs:
   ensure-header-updated:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `jobs` key was defined twice, causing test jobs to fail
(https://github.com/abetterinternet/crustls/actions/runs/522584929).