### PR TITLE
Add rustls_server_session_sni_hostname_get() to the API

### DIFF
--- a/src/crustls.h
+++ b/src/crustls.h
@@ -393,7 +393,7 @@ rustls_result rustls_server_session_write_tls(rustls_server_session *session,
                                               size_t *out_n);
 
 /**
- * Write up to `count` characters of the SNI hostname into `buf`. If the
+ * Write up to `len` characters of the SNI hostname into `buf`. If the
  * handshake has not been performed yet or if the client does not support SNI,
  * the returned length in out_n will be 0.
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.get_sni_hostname

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -392,4 +392,13 @@ rustls_result rustls_server_session_write_tls(rustls_server_session *session,
                                               size_t count,
                                               size_t *out_n);
 
+/**
+ * Write up to `count` characters of the SNI hostname into `buf`. If the
+ * handshake has not been performed yet or if the client does not support SNI,
+ * the returned length in out_n will be 0.
+ * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.get_sni_hostname
+ */
+rustls_result rustls_server_session_sni_hostname_get(rustls_server_session *session,
+                                                     char *buf, size_t len, size_t *out_n);
+
 #endif /* CRUSTLS_H */

--- a/src/main.c
+++ b/src/main.c
@@ -86,9 +86,14 @@ make_conn(const char *hostname)
 {
   int sockfd = 0;
   enum crustls_demo_result result = 0;
-  struct addrinfo *getaddrinfo_output = NULL;
+  struct addrinfo *getaddrinfo_output = NULL, hints;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM; /* looking for TCP */
+
   int getaddrinfo_result =
-    getaddrinfo(hostname, "443", NULL, &getaddrinfo_output);
+    getaddrinfo(hostname, "443", &hints, &getaddrinfo_output);
   if(getaddrinfo_result != 0) {
     fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(getaddrinfo_result));
     goto cleanup;

--- a/src/server.rs
+++ b/src/server.rs
@@ -404,7 +404,7 @@ pub extern "C" fn rustls_server_session_write_tls(
     }
 }
 
-/// Write up to `count` characters of the SNI hostname into `buf`. If the
+/// Write up to `len` characters of the SNI hostname into `buf`. If the
 /// handshake has not been performed yet or if the client does not support SNI,
 /// the returned length in out_n will be 0.
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.get_sni_hostname


### PR DESCRIPTION
Give C access to the SNI hostname provided by the TLS client. Follows naming and parameter patterns from other calls.

Feel free to discard this PR if you already worked on your side on this, of course.