### PR TITLE
Allow crustls to be used as an rlib dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 description = "C-to-rustls bindings"
 edition = "2018"
+links = "crustls"
 
 [dependencies]
 # Keep in sync with RUSTLS_CRATE_VERSION in lib.rs
@@ -19,4 +20,4 @@ cbindgen = "*"
 
 [lib]
 name = "crustls"
-crate-type = ["staticlib"]
+crate-type = ["lib", "staticlib"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let include_dir = out_dir.join("include");
+
+    fs::create_dir_all(&include_dir).unwrap();
+    fs::copy("src/crustls.h", include_dir.join("crustls.h")).unwrap();
+
+    println!("cargo:include={}", include_dir.to_str().unwrap());
+}


### PR DESCRIPTION
We are interested in enabling the rustls TLS backend from within [curl-rust](https://github.com/alexcrichton/curl-rust), the Rust bindings for libcurl, so that Rust code that depends on curl can opt-in to using rustls as the TLS backend using a Cargo feature. One potential way for us to implement this is for the crustls crate to allow being built as an rlib dependency and to depend on it via Cargo in order to expose the appropriate symbols in the binary.

This PR adds the required metadata that we would need for this to work after some initial testing, but in order to publish this as a supported feature we would need crustls to itself also be published to Crates.io.

Is this unusual use-case something you would be willing to officially support in crustls? If so then crustls would need to have its releases published to Crates.io. If not then that's OK as well as we have other options for implementing this in curl-rust (though not quite as convenient). I'd totally understand if this isn't something you want to maintain. I also realize that this is all very early in curl+rustls support and it might be too early to make this decision.

Here is the corresponding curl-rust PR that demonstrates how this would be used: https://github.com/alexcrichton/curl-rust/pull/374. For example, this exposes `DEP_CRUSTLS_INCLUDE` for curl-rust to access `crustls.h` to pass into the libcurl build.