### PR TITLE
Rework of new method rustls_server_session_get_sni_hostname()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: all
 target:
 	mkdir -p $@
 
-src/crustls.h: src/lib.rs src/error.rs
+src/crustls.h: src/lib.rs src/error.rs src/client.rs src/server.rs
 	cbindgen --lang C > $@
 
 target/crustls-demo: target/main.o target/$(PROFILE)/libcrustls.a

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -279,6 +279,15 @@ bool rustls_result_is_cert_error(enum rustls_result result);
 struct rustls_server_config_builder *rustls_server_config_builder_new(void);
 
 /**
+ * With `ignore` != 0, the server will ignore the client ordering of cipher
+ * suites, aka preference, during handshake and respect its own ordering
+ * as configured.
+ * https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html#fields
+ */
+enum rustls_result rustls_server_config_builder_set_ignore_client_order(struct rustls_server_config_builder *builder,
+                                                                        int8_t ignore);
+
+/**
  * Sets a single certificate chain and matching private key.
  * This certificate and key is used for all subsequent connections,
  * irrespective of things like SNI hostname.

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef enum {
+typedef enum rustls_result {
   RUSTLS_RESULT_OK = 7000,
   RUSTLS_RESULT_IO = 7001,
   RUSTLS_RESULT_NULL_PARAMETER = 7002,
@@ -14,6 +14,7 @@ typedef enum {
   RUSTLS_RESULT_PANIC = 7004,
   RUSTLS_RESULT_CERTIFICATE_PARSE_ERROR = 7005,
   RUSTLS_RESULT_PRIVATE_KEY_PARSE_ERROR = 7006,
+  RUSTLS_RESULT_INSUFFICIENT_SIZE = 7007,
   RUSTLS_RESULT_CORRUPT_MESSAGE = 7100,
   RUSTLS_RESULT_NO_CERTIFICATES_PRESENTED = 7101,
   RUSTLS_RESULT_DECRYPT_ERROR = 7102,
@@ -142,26 +143,26 @@ size_t rustls_version(char *buf, size_t len);
  * Caller must add roots with rustls_client_config_builder_load_native_roots
  * or rustls_client_config_builder_load_roots_from_file.
  */
-rustls_client_config_builder *rustls_client_config_builder_new(void);
+struct rustls_client_config_builder *rustls_client_config_builder_new(void);
 
 /**
  * Turn a *rustls_client_config_builder (mutable) into a *rustls_client_config
  * (read-only).
  */
-const rustls_client_config *rustls_client_config_builder_build(rustls_client_config_builder *builder);
+const struct rustls_client_config *rustls_client_config_builder_build(struct rustls_client_config_builder *builder);
 
 /**
  * Add certificates from platform's native root store, using
  * https://github.com/ctz/rustls-native-certs#readme.
  */
-rustls_result rustls_client_config_builder_load_native_roots(rustls_client_config_builder *config);
+enum rustls_result rustls_client_config_builder_load_native_roots(struct rustls_client_config_builder *config);
 
 /**
  * Add trusted root certificates from the named file, which should contain
  * PEM-formatted certificates.
  */
-rustls_result rustls_client_config_builder_load_roots_from_file(rustls_client_config_builder *config,
-                                                                const char *filename);
+enum rustls_result rustls_client_config_builder_load_roots_from_file(struct rustls_client_config_builder *config,
+                                                                     const char *filename);
 
 /**
  * "Free" a client_config previously returned from
@@ -171,7 +172,7 @@ rustls_result rustls_client_config_builder_load_roots_from_file(rustls_client_co
  * consider this pointer unusable after "free"ing it.
  * Calling with NULL is fine. Must not be called twice with the same value.
  */
-void rustls_client_config_free(const rustls_client_config *config);
+void rustls_client_config_free(const struct rustls_client_config *config);
 
 /**
  * Create a new rustls::ClientSession, and return it in the output parameter `out`.
@@ -180,29 +181,29 @@ void rustls_client_config_free(const rustls_client_config *config);
  * at a valid ClientSession. The caller now owns the ClientSession and must call
  * `rustls_client_session_free` when done with it.
  */
-rustls_result rustls_client_session_new(const rustls_client_config *config,
-                                        const char *hostname,
-                                        rustls_client_session **session_out);
+enum rustls_result rustls_client_session_new(const struct rustls_client_config *config,
+                                             const char *hostname,
+                                             struct rustls_client_session **session_out);
 
-bool rustls_client_session_wants_read(const rustls_client_session *session);
+bool rustls_client_session_wants_read(const struct rustls_client_session *session);
 
-bool rustls_client_session_wants_write(const rustls_client_session *session);
+bool rustls_client_session_wants_write(const struct rustls_client_session *session);
 
-bool rustls_client_session_is_handshaking(const rustls_client_session *session);
+bool rustls_client_session_is_handshaking(const struct rustls_client_session *session);
 
-rustls_result rustls_client_session_process_new_packets(rustls_client_session *session);
+enum rustls_result rustls_client_session_process_new_packets(struct rustls_client_session *session);
 
 /**
  * Queues a close_notify fatal alert to be sent in the next write_tls call.
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.send_close_notify
  */
-void rustls_client_session_send_close_notify(rustls_client_session *session);
+void rustls_client_session_send_close_notify(struct rustls_client_session *session);
 
 /**
  * Free a client_session previously returned from rustls_client_session_new.
  * Calling with NULL is fine. Must not be called twice with the same value.
  */
-void rustls_client_session_free(rustls_client_session *session);
+void rustls_client_session_free(struct rustls_client_session *session);
 
 /**
  * Write up to `count` plaintext bytes from `buf` into the ClientSession.
@@ -212,10 +213,10 @@ void rustls_client_session_free(rustls_client_session *session);
  * (this may be less than `count`).
  * https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.write
  */
-rustls_result rustls_client_session_write(rustls_client_session *session,
-                                          const uint8_t *buf,
-                                          size_t count,
-                                          size_t *out_n);
+enum rustls_result rustls_client_session_write(struct rustls_client_session *session,
+                                               const uint8_t *buf,
+                                               size_t count,
+                                               size_t *out_n);
 
 /**
  * Read up to `count` plaintext bytes from the ClientSession into `buf`.
@@ -226,10 +227,10 @@ rustls_result rustls_client_session_write(rustls_client_session *session,
  * rustls_client_session_process_new_packets."
  * https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.read
  */
-rustls_result rustls_client_session_read(rustls_client_session *session,
-                                         uint8_t *buf,
-                                         size_t count,
-                                         size_t *out_n);
+enum rustls_result rustls_client_session_read(struct rustls_client_session *session,
+                                              uint8_t *buf,
+                                              size_t count,
+                                              size_t *out_n);
 
 /**
  * Read up to `count` TLS bytes from `buf` (usually read from a socket) into
@@ -241,10 +242,10 @@ rustls_result rustls_client_session_read(rustls_client_session *session,
  * *out_n when the input count is 0.
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.read_tls
  */
-rustls_result rustls_client_session_read_tls(rustls_client_session *session,
-                                             const uint8_t *buf,
-                                             size_t count,
-                                             size_t *out_n);
+enum rustls_result rustls_client_session_read_tls(struct rustls_client_session *session,
+                                                  const uint8_t *buf,
+                                                  size_t count,
+                                                  size_t *out_n);
 
 /**
  * Write up to `count` TLS bytes from the ClientSession into `buf`. Those
@@ -252,10 +253,10 @@ rustls_result rustls_client_session_read_tls(rustls_client_session *session,
  * bytes actually written in *out_n (this maybe less than `count`).
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
  */
-rustls_result rustls_client_session_write_tls(rustls_client_session *session,
-                                              uint8_t *buf,
-                                              size_t count,
-                                              size_t *out_n);
+enum rustls_result rustls_client_session_write_tls(struct rustls_client_session *session,
+                                                   uint8_t *buf,
+                                                   size_t count,
+                                                   size_t *out_n);
 
 /**
  * After a rustls_client_session method returns an error, you may call
@@ -263,9 +264,9 @@ rustls_result rustls_client_session_write_tls(rustls_client_session *session,
  * message. The contents of the error buffer will be out_n bytes long,
  * UTF-8 encoded, and not NUL-terminated.
  */
-void rustls_error(rustls_result result, char *buf, size_t len, size_t *out_n);
+void rustls_error(enum rustls_result result, char *buf, size_t len, size_t *out_n);
 
-bool rustls_result_is_cert_error(rustls_result result);
+bool rustls_result_is_cert_error(enum rustls_result result);
 
 /**
  * Create a rustls_server_config_builder. Caller owns the memory and must
@@ -275,7 +276,7 @@ bool rustls_result_is_cert_error(rustls_result result);
  * or rustls_server_config_builder_load_roots_from_file.
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html#method.new
  */
-rustls_server_config_builder *rustls_server_config_builder_new(void);
+struct rustls_server_config_builder *rustls_server_config_builder_new(void);
 
 /**
  * Sets a single certificate chain and matching private key.
@@ -287,17 +288,17 @@ rustls_server_config_builder *rustls_server_config_builder_new(void);
  * private_key must point to a byte array of length private_key_len containing
  * a private key in PEM-encoded PKCS#8 or PKCS#1 format.
  */
-rustls_result rustls_server_config_builder_set_single_cert_pem(rustls_server_config_builder *builder,
-                                                               const uint8_t *cert_chain,
-                                                               size_t cert_chain_len,
-                                                               const uint8_t *private_key,
-                                                               size_t private_key_len);
+enum rustls_result rustls_server_config_builder_set_single_cert_pem(struct rustls_server_config_builder *builder,
+                                                                    const uint8_t *cert_chain,
+                                                                    size_t cert_chain_len,
+                                                                    const uint8_t *private_key,
+                                                                    size_t private_key_len);
 
 /**
  * Turn a *rustls_server_config_builder (mutable) into a *rustls_server_config
  * (read-only).
  */
-const rustls_server_config *rustls_server_config_builder_build(rustls_server_config_builder *builder);
+const struct rustls_server_config *rustls_server_config_builder_build(struct rustls_server_config_builder *builder);
 
 /**
  * "Free" a server_config previously returned from
@@ -307,7 +308,7 @@ const rustls_server_config *rustls_server_config_builder_build(rustls_server_con
  * consider this pointer unusable after "free"ing it.
  * Calling with NULL is fine. Must not be called twice with the same value.
  */
-void rustls_server_config_free(const rustls_server_config *config);
+void rustls_server_config_free(const struct rustls_server_config *config);
 
 /**
  * Create a new rustls::ServerSession, and return it in the output parameter `out`.
@@ -316,28 +317,28 @@ void rustls_server_config_free(const rustls_server_config *config);
  * at a valid ServerSession. The caller now owns the ServerSession and must call
  * `rustls_server_session_free` when done with it.
  */
-rustls_result rustls_server_session_new(const rustls_server_config *config,
-                                        rustls_server_session **session_out);
+enum rustls_result rustls_server_session_new(const struct rustls_server_config *config,
+                                             struct rustls_server_session **session_out);
 
-bool rustls_server_session_wants_read(const rustls_server_session *session);
+bool rustls_server_session_wants_read(const struct rustls_server_session *session);
 
-bool rustls_server_session_wants_write(const rustls_server_session *session);
+bool rustls_server_session_wants_write(const struct rustls_server_session *session);
 
-bool rustls_server_session_is_handshaking(const rustls_server_session *session);
+bool rustls_server_session_is_handshaking(const struct rustls_server_session *session);
 
-rustls_result rustls_server_session_process_new_packets(rustls_server_session *session);
+enum rustls_result rustls_server_session_process_new_packets(struct rustls_server_session *session);
 
 /**
  * Queues a close_notify fatal alert to be sent in the next write_tls call.
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.send_close_notify
  */
-void rustls_server_session_send_close_notify(rustls_server_session *session);
+void rustls_server_session_send_close_notify(struct rustls_server_session *session);
 
 /**
  * Free a server_session previously returned from rustls_server_session_new.
  * Calling with NULL is fine. Must not be called twice with the same value.
  */
-void rustls_server_session_free(rustls_server_session *session);
+void rustls_server_session_free(struct rustls_server_session *session);
 
 /**
  * Write up to `count` plaintext bytes from `buf` into the ServerSession.
@@ -347,10 +348,10 @@ void rustls_server_session_free(rustls_server_session *session);
  * (this may be less than `count`).
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.write
  */
-rustls_result rustls_server_session_write(rustls_server_session *session,
-                                          const uint8_t *buf,
-                                          size_t count,
-                                          size_t *out_n);
+enum rustls_result rustls_server_session_write(struct rustls_server_session *session,
+                                               const uint8_t *buf,
+                                               size_t count,
+                                               size_t *out_n);
 
 /**
  * Read up to `count` plaintext bytes from the ServerSession into `buf`.
@@ -361,10 +362,10 @@ rustls_result rustls_server_session_write(rustls_server_session *session,
  * rustls_server_session_process_new_packets."
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.read
  */
-rustls_result rustls_server_session_read(rustls_server_session *session,
-                                         uint8_t *buf,
-                                         size_t count,
-                                         size_t *out_n);
+enum rustls_result rustls_server_session_read(struct rustls_server_session *session,
+                                              uint8_t *buf,
+                                              size_t count,
+                                              size_t *out_n);
 
 /**
  * Read up to `count` TLS bytes from `buf` (usually read from a socket) into
@@ -376,10 +377,10 @@ rustls_result rustls_server_session_read(rustls_server_session *session,
  * *out_n when the input count is 0.
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.read_tls
  */
-rustls_result rustls_server_session_read_tls(rustls_server_session *session,
-                                             const uint8_t *buf,
-                                             size_t count,
-                                             size_t *out_n);
+enum rustls_result rustls_server_session_read_tls(struct rustls_server_session *session,
+                                                  const uint8_t *buf,
+                                                  size_t count,
+                                                  size_t *out_n);
 
 /**
  * Write up to `count` TLS bytes from the ServerSession into `buf`. Those
@@ -387,9 +388,21 @@ rustls_result rustls_server_session_read_tls(rustls_server_session *session,
  * bytes actually written in *out_n (this maybe less than `count`).
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
  */
-rustls_result rustls_server_session_write_tls(rustls_server_session *session,
-                                              uint8_t *buf,
-                                              size_t count,
-                                              size_t *out_n);
+enum rustls_result rustls_server_session_write_tls(struct rustls_server_session *session,
+                                                   uint8_t *buf,
+                                                   size_t count,
+                                                   size_t *out_n);
+
+/**
+ * Copy the SNI hostname to `buf` wich can hold up  to `count` bytes,
+ * and the length of that hostname in `out_n`. The string is stored in UTF-8
+ * with no terminating NUL byte.
+ * Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
+ * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.get_sni_hostname
+ */
+enum rustls_result rustls_server_session_sni_hostname_get(const struct rustls_server_session *session,
+                                                          uint8_t *buf,
+                                                          size_t count,
+                                                          size_t *out_n);
 
 #endif /* CRUSTLS_H */

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -409,7 +409,7 @@ enum rustls_result rustls_server_session_write_tls(struct rustls_server_session 
  * Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.get_sni_hostname
  */
-enum rustls_result rustls_server_session_sni_hostname_get(const struct rustls_server_session *session,
+enum rustls_result rustls_server_session_get_sni_hostname(const struct rustls_server_session *session,
                                                           uint8_t *buf,
                                                           size_t count,
                                                           size_t *out_n);

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -285,7 +285,7 @@ struct rustls_server_config_builder *rustls_server_config_builder_new(void);
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html#fields
  */
 enum rustls_result rustls_server_config_builder_set_ignore_client_order(struct rustls_server_config_builder *builder,
-                                                                        int8_t ignore);
+                                                                        bool ignore);
 
 /**
  * Sets a single certificate chain and matching private key.
@@ -403,10 +403,12 @@ enum rustls_result rustls_server_session_write_tls(struct rustls_server_session 
                                                    size_t *out_n);
 
 /**
- * Copy the SNI hostname to `buf` wich can hold up  to `count` bytes,
+ * Copy the SNI hostname to `buf` which can hold up  to `count` bytes,
  * and the length of that hostname in `out_n`. The string is stored in UTF-8
  * with no terminating NUL byte.
  * Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
+ * Returns Ok with *out_n == 0 if there is no SNI hostname available on this session
+ * because it hasn't been processed yet, or because the client did not send SNI.
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.get_sni_hostname
  */
 enum rustls_result rustls_server_session_get_sni_hostname(const struct rustls_server_session *session,

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,7 @@ pub enum rustls_result {
     Panic = 7004,
     CertificateParseError = 7005,
     PrivateKeyParseError = 7006,
+    InsufficientSize = 7007,
 
     // From https://docs.rs/rustls/0.19.0/rustls/enum.TLSError.html
     CorruptMessage = 7100,
@@ -270,6 +271,7 @@ fn result_to_tlserror(input: &rustls_result) -> Either {
         Panic => return Either::String("a Rust component panicked".to_string()),
         CertificateParseError => return Either::String("error parsing certificate".to_string()),
         PrivateKeyParseError => return Either::String("error parsing private key".to_string()),
+        InsufficientSize => return Either::String("provided buffer is of insufficient size".to_string()),
 
         // These variants correspond to a TLSError variant with a field,
         // where generating an arbitrary field would produce a confusing error
@@ -292,6 +294,7 @@ fn result_to_tlserror(input: &rustls_result) -> Either {
         Panic => unreachable!(),
         CertificateParseError => unreachable!(),
         PrivateKeyParseError => unreachable!(),
+        InsufficientSize => unreachable!(),
 
         InappropriateMessage => unreachable!(),
         InappropriateHandshakeMessage => unreachable!(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -62,6 +62,22 @@ pub extern "C" fn rustls_server_config_builder_new() -> *mut rustls_server_confi
     }
 }
 
+/// With `ignore` != 0, the server will ignore the client ordering of cipher
+/// suites, aka preference, during handshake and respect its own ordering
+/// as configured.
+/// https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html#fields
+#[no_mangle]
+pub extern "C" fn rustls_server_config_builder_set_ignore_client_order(
+    builder: *mut rustls_server_config_builder,
+    ignore: i8,
+) -> rustls_result {
+    ffi_panic_boundary! {
+        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig);
+        config.ignore_client_order = ignore != 0;
+        rustls_result::Ok
+    }
+}
+
 /// Sets a single certificate chain and matching private key.
 /// This certificate and key is used for all subsequent connections,
 /// irrespective of things like SNI hostname.

--- a/src/server.rs
+++ b/src/server.rs
@@ -425,7 +425,7 @@ pub extern "C" fn rustls_server_session_write_tls(
 /// Returns RUSTLS_RESULT_INSUFFICIENT_SIZE if the SNI hostname is longer than `count`.
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.get_sni_hostname
 #[no_mangle]
-pub extern "C" fn rustls_server_session_sni_hostname_get(
+pub extern "C" fn rustls_server_session_get_sni_hostname(
     session: *const rustls_server_session,
     buf: *mut u8,
     count: size_t,

--- a/src/server.rs
+++ b/src/server.rs
@@ -460,6 +460,6 @@ pub extern "C" fn rustls_server_session_get_sni_hostname(
         unsafe {
             *out_n = len;
         }
-        return rustls_result::Ok
+        rustls_result::Ok
     }
 }


### PR DESCRIPTION
Rework of the method to access the SNI hostname of the session after
review by others.