### PR TITLE
Add rustls_str, rustls_slice_bytes, and friends

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make src/crustls.h
-      - run: git diff
+      - run: git diff --exit-code
 
   cargo-fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,3 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: cargo fmt -- --check
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo +nightly miri test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - rustup toolchain install nightly
+      - rustup component add miri
+      - cargo install xargo
       - run: cargo +nightly miri test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: rustup toolchain install nightly
+      - run: rustup default nightly
       - run: rustup component add miri
       - run: cargo install xargo
       - run: cargo +nightly miri test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - rustup toolchain install nightly
-      - rustup component add miri
-      - cargo install xargo
+      - run: rustup toolchain install nightly
+      - run: rustup component add miri
+      - run: cargo install xargo
       - run: cargo +nightly miri test

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,14 @@ endif
 all: target/crustls-demo
 
 test: all
+	cargo test
 	target/crustls-demo httpbin.org /headers
 
 target:
 	mkdir -p $@
 
 src/crustls.h: src/*.rs
+	cargo check
 	cbindgen --lang C > $@
 
 target/crustls-demo: target/main.o target/$(PROFILE)/libcrustls.a

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -342,7 +342,7 @@ bool rustls_result_is_cert_error(enum rustls_result result);
  * Retrieve the nth element from the input slice of slices. If the input
  * pointer is NULL, returns 0.
  */
-uintptr_t rustls_slice_slice_bytes_len(const struct rustls_slice_slice_bytes *input);
+size_t rustls_slice_slice_bytes_len(const struct rustls_slice_slice_bytes *input);
 
 /**
  * Retrieve the nth element from the input slice of slices. If the input
@@ -350,20 +350,20 @@ uintptr_t rustls_slice_slice_bytes_len(const struct rustls_slice_slice_bytes *in
  * rustls_slice_slice_bytes, returns rustls_slice_bytes{NULL, 0}.
  */
 struct rustls_slice_bytes rustls_slice_slice_bytes_get(const struct rustls_slice_slice_bytes *input,
-                                                       uintptr_t n);
+                                                       size_t n);
 
 /**
  * Retrieve the nth element from the input slice of slices. If the input
  * pointer is NULL, returns 0.
  */
-uintptr_t rustls_slice_str_len(const struct rustls_slice_str *input);
+size_t rustls_slice_str_len(const struct rustls_slice_str *input);
 
 /**
  * Retrieve the nth element from the input slice of slices. If the input
  * pointer is NULL, or n is greater than the length of the
  * rustls_slice_slice_bytes, returns rustls_str{NULL, 0}.
  */
-struct rustls_str rustls_slice_str_get(const struct rustls_slice_str *input, uintptr_t n);
+struct rustls_str rustls_slice_str_get(const struct rustls_slice_str *input, size_t n);
 
 /**
  * Create a rustls_server_config_builder. Caller owns the memory and must

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -147,7 +147,9 @@ typedef struct rustls_server_session rustls_server_session;
 typedef struct rustls_slice_slice_bytes rustls_slice_slice_bytes;
 
 /**
- * A read-only view of a slice of Rust `&str`.
+ * A read-only view of a slice of multiple Rust `&str`'s (that is, multiple
+ * strings). Like `rustls_str`, this guarantees that each string contains
+ * UTF-8 and no NUL bytes. Strings are not NUL-terminated.
  *
  * This is used to pass data from crustls to callback functions provided
  * by the user of the API. Because Vec and slice are not `#[repr(C)]`, we

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -130,6 +130,76 @@ typedef struct rustls_server_config_builder rustls_server_config_builder;
 typedef struct rustls_server_session rustls_server_session;
 
 /**
+ * A read-only view of a slice of Rust byte slices.
+ *
+ * This is used to pass data from crustls to callback functions provided
+ * by the user of the API. Because Vec and slice are not `#[repr(C)]`, we
+ * provide access via a pointer to an opaque struct and an accessor method
+ * that acts on that struct to get entries of type `rustls_slice_bytes`.
+ * Internally, the pointee is a `&[&[u8]]`.
+ *
+ * The memory exposed is available as specified by the function
+ * using this in its signature. For instance, when this is a parameter to a
+ * callback, the lifetime will usually be the duration of the callback.
+ * Functions that receive one of these must not call its methods beyond the
+ * allowed lifetime.
+ */
+typedef struct rustls_slice_slice_bytes rustls_slice_slice_bytes;
+
+/**
+ * A read-only view of a slice of Rust `&str`.
+ *
+ * This is used to pass data from crustls to callback functions provided
+ * by the user of the API. Because Vec and slice are not `#[repr(C)]`, we
+ * can't provide a straightforward `data` and `len` structure. Instead, we
+ * provide access via a pointer to an opaque struct and accessor methods.
+ * Internally, the pointee is a `&[&str]`.
+ *
+ * The memory exposed is available as specified by the function
+ * using this in its signature. For instance, when this is a parameter to a
+ * callback, the lifetime will usually be the duration of the callback.
+ * Functions that receive one of these must not call its methods beyond the
+ * allowed lifetime.
+ */
+typedef struct rustls_slice_str rustls_slice_str;
+
+/**
+ * A read-only view on a Rust byte slice.
+ *
+ * This is used to pass data from crustls to callback functions provided
+ * by the user of the API.
+ * `len` indicates the number of bytes than can be safely read.
+ *
+ * The memory exposed is available as specified by the function
+ * using this in its signature. For instance, when this is a parameter to a
+ * callback, the lifetime will usually be the duration of the callback.
+ * Functions that receive one of these must not dereference the data pointer
+ * beyond the allowed lifetime.
+ */
+typedef struct rustls_slice_bytes {
+  const uint8_t *data;
+  size_t len;
+} rustls_slice_bytes;
+
+/**
+ * A read-only view on a Rust `&str`. The contents are guaranteed to be valid
+ * UTF-8. As an additional guarantee on top of Rust's normal UTF-8 guarantee,
+ * a `rustls_str` is guaranteed not to contain internal NUL bytes, so it is
+ * safe to interpolate into a C string or compare using strncmp. Keep in mind
+ * that it is not NUL-terminated.
+ *
+ * The memory exposed is available as specified by the function
+ * using this in its signature. For instance, when this is a parameter to a
+ * callback, the lifetime will usually be the duration of the callback.
+ * Functions that receive one of these must not dereference the data pointer
+ * beyond the allowed lifetime.
+ */
+typedef struct rustls_str {
+  const char *data;
+  size_t len;
+} rustls_str;
+
+/**
  * Write the version of the crustls C bindings and rustls itself into the
  * provided buffer, up to a max of `len` bytes. Output is UTF-8 encoded
  * and NUL terminated. Returns the number of bytes written before the NUL.
@@ -267,6 +337,33 @@ enum rustls_result rustls_client_session_write_tls(struct rustls_client_session 
 void rustls_error(enum rustls_result result, char *buf, size_t len, size_t *out_n);
 
 bool rustls_result_is_cert_error(enum rustls_result result);
+
+/**
+ * Retrieve the nth element from the input slice of slices. If the input
+ * pointer is NULL, returns 0.
+ */
+uintptr_t rustls_slice_slice_bytes_len(const struct rustls_slice_slice_bytes *input);
+
+/**
+ * Retrieve the nth element from the input slice of slices. If the input
+ * pointer is NULL, or n is greater than the length of the
+ * rustls_slice_slice_bytes, returns rustls_slice_bytes{NULL, 0}.
+ */
+struct rustls_slice_bytes rustls_slice_slice_bytes_get(const struct rustls_slice_slice_bytes *input,
+                                                       uintptr_t n);
+
+/**
+ * Retrieve the nth element from the input slice of slices. If the input
+ * pointer is NULL, returns 0.
+ */
+uintptr_t rustls_slice_str_len(const struct rustls_slice_str *input);
+
+/**
+ * Retrieve the nth element from the input slice of slices. If the input
+ * pointer is NULL, or n is greater than the length of the
+ * rustls_slice_slice_bytes, returns rustls_str{NULL, 0}.
+ */
+struct rustls_str rustls_slice_str_get(const struct rustls_slice_str *input, uintptr_t n);
 
 /**
  * Create a rustls_server_config_builder. Caller owns the memory and must

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -341,8 +341,8 @@ void rustls_error(enum rustls_result result, char *buf, size_t len, size_t *out_
 bool rustls_result_is_cert_error(enum rustls_result result);
 
 /**
- * Retrieve the nth element from the input slice of slices. If the input
- * pointer is NULL, returns 0.
+ * Return the length of the outer slice. If the input pointer is NULL,
+ * returns 0.
  */
 size_t rustls_slice_slice_bytes_len(const struct rustls_slice_slice_bytes *input);
 
@@ -355,13 +355,13 @@ struct rustls_slice_bytes rustls_slice_slice_bytes_get(const struct rustls_slice
                                                        size_t n);
 
 /**
- * Retrieve the nth element from the input slice of slices. If the input
- * pointer is NULL, returns 0.
+ * Return the length of the outer slice. If the input pointer is NULL,
+ * returns 0.
  */
 size_t rustls_slice_str_len(const struct rustls_slice_str *input);
 
 /**
- * Retrieve the nth element from the input slice of slices. If the input
+ * Retrieve the nth element from the input slice of `&str`s. If the input
  * pointer is NULL, or n is greater than the length of the
  * rustls_slice_str, returns rustls_str{NULL, 0}.
  */

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -361,7 +361,7 @@ size_t rustls_slice_str_len(const struct rustls_slice_str *input);
 /**
  * Retrieve the nth element from the input slice of slices. If the input
  * pointer is NULL, or n is greater than the length of the
- * rustls_slice_slice_bytes, returns rustls_str{NULL, 0}.
+ * rustls_slice_str, returns rustls_str{NULL, 0}.
  */
 struct rustls_str rustls_slice_str_get(const struct rustls_slice_str *input, size_t n);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::{mem, slice};
 
 mod client;
 mod error;
+mod rslice;
 mod server;
 
 // Keep in sync with Cargo.toml.

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -96,8 +96,12 @@ pub struct rustls_str<'a> {
     phantom: PhantomData<&'a str>,
 }
 
+/// NulByte represents an error converting `&str` to `rustls_str` when the &str
+/// contains a NUL.
+type NulByte = ();
+
 impl<'a> TryFrom<&'a str> for rustls_str<'a> {
-    type Error = ();
+    type Error = NulByte;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         if s.contains('\0') {

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -119,15 +119,9 @@ fn test_rustls_slice_slice_bytes() {
 
     unsafe {
         assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 0).data, b'a');
-        assert_eq!(
-            *rustls_slice_slice_bytes_get(&rssb, 0).data.offset(3),
-            b'd'
-        );
+        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 0).data.offset(3), b'd');
         assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 2).data, b'x');
-        assert_eq!(
-            *rustls_slice_slice_bytes_get(&rssb, 2).data.offset(2),
-            b'z'
-        );
+        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 2).data.offset(2), b'z');
     }
 }
 

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -23,8 +23,8 @@ pub struct rustls_slice_bytes<'a> {
 impl<'a> From<&'a [u8]> for rustls_slice_bytes<'a> {
     fn from(s: &[u8]) -> Self {
         rustls_slice_bytes {
-            data: s.as_ptr() as *const u8,
-            len: s.len() as size_t,
+            data: s.as_ptr(),
+            len: s.len(),
             phantom: PhantomData,
         }
     }
@@ -117,7 +117,7 @@ impl<'a> TryFrom<&'a str> for rustls_str<'a> {
         }
         Ok(rustls_str {
             data: s.as_ptr() as *const c_char,
-            len: s.len() as size_t,
+            len: s.len(),
             phantom: PhantomData,
         })
     }
@@ -207,8 +207,8 @@ pub struct rustls_slice_u16<'a> {
 impl<'a> From<&'a [u16]> for rustls_slice_u16<'a> {
     fn from(s: &[u16]) -> Self {
         rustls_slice_u16 {
-            data: s.as_ptr() as *const u16,
-            len: s.len() as size_t,
+            data: s.as_ptr(),
+            len: s.len(),
             phantom: PhantomData,
         }
     }

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -11,8 +11,8 @@ use std::marker::PhantomData;
 /// The memory exposed is available as specified by the function
 /// using this in its signature. For instance, when this is a parameter to a
 /// callback, the lifetime will usually be the duration of the callback.
-/// Functions that receive one of these must not retain copies of any of the
-/// pointers beyond the allowed lifetime.
+/// Functions that receive one of these must not dereference the data pointer
+/// beyond the allowed lifetime.
 #[repr(C)]
 pub struct rustls_slice_bytes<'a> {
     pub data: *const u8,
@@ -59,8 +59,8 @@ impl<'a> VecSliceBytes<'a> {
 /// The memory exposed is available as specified by the function
 /// using this in its signature. For instance, when this is a parameter to a
 /// callback, the lifetime will usually be the duration of the callback.
-/// Functions that receive one of these must not retain copies of any of the
-/// pointers beyond the allowed lifetime.
+/// Functions that receive one of these must not dereference any of the
+/// involved data pointers beyond the allowed lifetime.
 #[repr(C)]
 pub struct rustls_slice_slice_bytes<'a> {
     data: *const rustls_slice_bytes<'a>,
@@ -87,8 +87,8 @@ impl<'a> From<&'a VecSliceBytes<'a>> for rustls_slice_slice_bytes<'a> {
 /// The memory exposed is available as specified by the function
 /// using this in its signature. For instance, when this is a parameter to a
 /// callback, the lifetime will usually be the duration of the callback.
-/// Functions that receive one of these must not retain copies of any of the
-/// pointers beyond the allowed lifetime.
+/// Functions that receive one of these must not dereference the data pointer
+/// beyond the allowed lifetime.
 #[repr(C)]
 pub struct rustls_str<'a> {
     pub data: *const c_char,
@@ -136,8 +136,8 @@ impl<'a> VecStr<'a> {
 /// The memory exposed is available as specified by the function
 /// using this in its signature. For instance, when this is a parameter to a
 /// callback, the lifetime will usually be the duration of the callback.
-/// Functions that receive one of these must not retain copies of any of the
-/// pointers beyond the allowed lifetime.
+/// Functions that receive one of these must not dereference any of the
+/// involved pointers beyond the allowed lifetime.
 #[repr(C)]
 pub struct rustls_slice_str<'a> {
     pub data: *const rustls_str<'a>,
@@ -164,8 +164,8 @@ impl<'a> From<&'a VecStr<'a>> for rustls_slice_str<'a> {
 /// The memory exposed is available as specified by the function
 /// using this in its signature. For instance, when this is a parameter to a
 /// callback, the lifetime will usually be the duration of the callback.
-/// Functions that receive one of these must not retain copies of any of the
-/// pointers beyond the allowed lifetime.
+/// Functions that receive one of these must not dereference the data pointer
+/// beyond the allowed lifetime.
 #[repr(C)]
 pub struct rustls_slice_u16<'a> {
     pub data: *const u16,

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -52,10 +52,9 @@ pub struct rustls_slice_slice_bytes<'a> {
 
 /// Return a pointer to a rustls_slice_slice_bytes representing an input slice.
 pub(crate) fn rustls_slice_slice_bytes_new<'a>(
-    input: &'a [&'a [u8]],
+    input: &&'a [&'a [u8]],
 ) -> *const rustls_slice_slice_bytes<'a> {
-    let output: &&[&[u8]] = &input;
-    let output: *const &[&[u8]] = output;
+    let output: *const &[&[u8]] = input;
     output as *const rustls_slice_slice_bytes
 }
 
@@ -158,14 +157,13 @@ pub struct rustls_slice_str<'a> {
 /// Return a pointer to a rustls_slice_str representing a an input slice.
 /// If any element of the input slice doesn't mean the `rustls_str` invariant
 /// of having no NUL bytes, return NULL.
-pub(crate) fn rustls_slice_str_new<'a>(input: &'a [&'a str]) -> *const rustls_slice_str<'a> {
-    for &s in input {
+pub(crate) fn rustls_slice_str_new<'a>(input: &&'a [&'a str]) -> *const rustls_slice_str<'a> {
+    for &s in *input {
         if let Err(NulByte {}) = rustls_str::try_from(s) {
             return null();
         }
     }
-    let output: &&[&str] = &input;
-    let output: *const &[&str] = output;
+    let output: *const &[&str] = input;
     output as *const rustls_slice_str
 }
 

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -58,7 +58,7 @@ fn test_rustls_slice_bytes() {
 /// Functions that receive one of these must not call its methods beyond the
 /// allowed lifetime.
 pub struct rustls_slice_slice_bytes<'a> {
-    pub inner: &'a [&'a [u8]],
+    pub(crate) inner: &'a [&'a [u8]],
 }
 
 /// Return the length of the outer slice. If the input pointer is NULL,
@@ -197,7 +197,7 @@ fn test_rustls_str_rejects_nul() {
 /// Functions that receive one of these must not call its methods beyond the
 /// allowed lifetime.
 pub struct rustls_slice_str<'a> {
-    pub inner: &'a [&'a str],
+    pub(crate) inner: &'a [&'a str],
 }
 
 /// Return the length of the outer slice. If the input pointer is NULL,
@@ -212,7 +212,7 @@ pub extern "C" fn rustls_slice_str_len(input: *const rustls_slice_str) -> size_t
     }
 }
 
-/// Retrieve the nth element from the input slice of slices. If the input
+/// Retrieve the nth element from the input slice of `&str`s. If the input
 /// pointer is NULL, or n is greater than the length of the
 /// rustls_slice_str, returns rustls_str{NULL, 0}.
 #[no_mangle]

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -53,7 +53,7 @@ pub struct rustls_slice_slice_bytes<'a> {
 /// Return a pointer to a rustls_slice_slice_bytes representing an input slice.
 pub(crate) fn rustls_slice_slice_bytes_new<'a>(
     input: &'a [&'a [u8]],
-) -> *const rustls_slice_slice_bytes {
+) -> *const rustls_slice_slice_bytes<'a> {
     let output: &&[&[u8]] = &input;
     let output: *const &[&[u8]] = output;
     output as *const rustls_slice_slice_bytes
@@ -62,7 +62,7 @@ pub(crate) fn rustls_slice_slice_bytes_new<'a>(
 /// Retrieve the nth element from the input slice of slices. If the input
 /// pointer is NULL, returns 0.
 #[no_mangle]
-pub extern "C" fn rustls_slice_slice_bytes_len(input: *const rustls_slice_slice_bytes) -> usize {
+pub extern "C" fn rustls_slice_slice_bytes_len(input: *const rustls_slice_slice_bytes) -> size_t {
     unsafe {
         match (input as *const &[&[u8]]).as_ref() {
             Some(c) => c.len(),
@@ -75,10 +75,10 @@ pub extern "C" fn rustls_slice_slice_bytes_len(input: *const rustls_slice_slice_
 /// pointer is NULL, or n is greater than the length of the
 /// rustls_slice_slice_bytes, returns rustls_slice_bytes{NULL, 0}.
 #[no_mangle]
-pub extern "C" fn rustls_slice_slice_bytes_get(
-    input: *const rustls_slice_slice_bytes,
-    n: usize,
-) -> rustls_slice_bytes {
+pub extern "C" fn rustls_slice_slice_bytes_get<'a>(
+    input: *const rustls_slice_slice_bytes<'a>,
+    n: size_t,
+) -> rustls_slice_bytes<'a> {
     let input: &&[&[u8]] = unsafe {
         match (input as *const &[&[u8]]).as_ref() {
             Some(c) => c,
@@ -172,7 +172,7 @@ pub(crate) fn rustls_slice_str_new<'a>(input: &'a [&'a str]) -> *const rustls_sl
 /// Retrieve the nth element from the input slice of slices. If the input
 /// pointer is NULL, returns 0.
 #[no_mangle]
-pub extern "C" fn rustls_slice_str_len(input: *const rustls_slice_str) -> usize {
+pub extern "C" fn rustls_slice_str_len(input: *const rustls_slice_str) -> size_t {
     unsafe {
         match (input as *const &[&str]).as_ref() {
             Some(c) => c.len(),
@@ -185,7 +185,7 @@ pub extern "C" fn rustls_slice_str_len(input: *const rustls_slice_str) -> usize 
 /// pointer is NULL, or n is greater than the length of the
 /// rustls_slice_slice_bytes, returns rustls_str{NULL, 0}.
 #[no_mangle]
-pub extern "C" fn rustls_slice_str_get(input: *const rustls_slice_str, n: usize) -> rustls_str {
+pub extern "C" fn rustls_slice_str_get(input: *const rustls_slice_str, n: size_t) -> rustls_str {
     let input: &&[&str] = unsafe {
         match (input as *const &[&str]).as_ref() {
             Some(c) => c,

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -1,0 +1,184 @@
+use libc::{c_char, size_t};
+use std::convert::{TryFrom, TryInto};
+use std::marker::PhantomData;
+
+/// A read-only view on a Rust byte slice.
+///
+/// This is used to pass data from crustls to callback functions provided
+/// by the user of the API.
+/// `len` indicates the number of bytes than can be safely read.
+///
+/// The memory exposed is available as specified by the function
+/// using this in its signature. For instance, when this is a parameter to a
+/// callback, the lifetime will usually be the duration of the callback.
+/// Functions that receive one of these must not retain copies of any of the
+/// pointers beyond the allowed lifetime.
+#[repr(C)]
+pub struct rustls_slice_bytes<'a> {
+    pub data: *const u8,
+    pub len: size_t,
+    phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> From<&'a [u8]> for rustls_slice_bytes<'a> {
+    fn from(s: &[u8]) -> Self {
+        rustls_slice_bytes {
+            data: s.as_ptr() as *const u8,
+            len: s.len() as size_t,
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// An owned Vec<rustls_slice_bytes>, where the inner slices have lifetime 'a.
+/// If we want to share a view of a `Vec<Vec<_>>` with C, we can't do it
+/// directly because `Vec` is not #[repr(C)]. So we build a new Vec containing
+/// rustls_slice_bytes<'a> as an owned object. We can then expose slices of
+/// that Vec to C.
+pub(crate) struct VecSliceBytes<'a>(Vec<rustls_slice_bytes<'a>>);
+
+impl<'a> VecSliceBytes<'a> {
+    /// Build a VecSliceBytes that refers to `input` and can live as long as
+    /// it does.
+    fn new(input: &'a Vec<Vec<u8>>) -> Self {
+        let mut vv: Vec<rustls_slice_bytes> = vec![];
+        for v in input {
+            let v: &[u8] = v.as_ref();
+            vv.push(v.into());
+        }
+        VecSliceBytes(vv)
+    }
+}
+
+/// A read-only view of a slice of Rust byte slices.
+///
+/// This is used to pass data from crustls to callback functions provided
+/// by the user of the API. The `data` is an array of `rustls_slice_bytes`
+/// structures with `len` elements.
+///
+/// The memory exposed is available as specified by the function
+/// using this in its signature. For instance, when this is a parameter to a
+/// callback, the lifetime will usually be the duration of the callback.
+/// Functions that receive one of these must not retain copies of any of the
+/// pointers beyond the allowed lifetime.
+#[repr(C)]
+pub struct rustls_slice_slice_bytes<'a> {
+    data: *const rustls_slice_bytes<'a>,
+    len: size_t,
+    phantom: PhantomData<&'a [&'a [u8]]>,
+}
+
+impl<'a> From<&'a VecSliceBytes<'a>> for rustls_slice_slice_bytes<'a> {
+    fn from(input: &'a VecSliceBytes<'a>) -> Self {
+        rustls_slice_slice_bytes {
+            data: input.0.as_ptr(),
+            len: input.0.len(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// A read-only view on a Rust `&str`. The contents are guaranteed to be valid
+/// UTF-8. As an additional guarantee on top of Rust's normal UTF-8 guarantee,
+/// a `rustls_str` is guaranteed not to contain internal NUL bytes, so it is
+/// safe to interpolate into a C string or compare using strncmp. Keep in mind
+/// that it is not NUL-terminated.
+///
+/// The memory exposed is available as specified by the function
+/// using this in its signature. For instance, when this is a parameter to a
+/// callback, the lifetime will usually be the duration of the callback.
+/// Functions that receive one of these must not retain copies of any of the
+/// pointers beyond the allowed lifetime.
+#[repr(C)]
+pub struct rustls_str<'a> {
+    pub data: *const c_char,
+    pub len: size_t,
+    phantom: PhantomData<&'a str>,
+}
+
+impl<'a> TryFrom<&'a str> for rustls_str<'a> {
+    type Error = ();
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        if s.contains('\0') {
+            return Err(());
+        }
+        Ok(rustls_str {
+            data: s.as_ptr() as *const c_char,
+            len: s.len() as size_t,
+            phantom: PhantomData,
+        })
+    }
+}
+
+/// An owned Vec<rustls_str>, where the inner slices have lifetime 'a.
+/// See comment on VecSliceBytes for more information.
+pub(crate) struct VecStr<'a>(Vec<rustls_str<'a>>);
+
+impl<'a> VecStr<'a> {
+    /// Build a VecStr that refers to `input` and can live as long as it does.
+    fn new(input: &'a Vec<&str>) -> Result<Self, ()> {
+        let mut vs: Vec<rustls_str> = vec![];
+        for v in input {
+            let v: &str = v.as_ref();
+            vs.push(v.try_into()?);
+        }
+        Ok(VecStr(vs))
+    }
+}
+
+/// A read-only view of a slice of Rust `&str`
+///
+/// This is used to pass data from crustls to callback functions provided
+/// by the user of the API. The `data` is an array of `rustls_str`
+/// structures with `len` elements.
+///
+/// The memory exposed is available as specified by the function
+/// using this in its signature. For instance, when this is a parameter to a
+/// callback, the lifetime will usually be the duration of the callback.
+/// Functions that receive one of these must not retain copies of any of the
+/// pointers beyond the allowed lifetime.
+#[repr(C)]
+pub struct rustls_slice_str<'a> {
+    pub data: *const rustls_str<'a>,
+    pub len: size_t,
+    phantom: PhantomData<&'a [&'a str]>,
+}
+
+impl<'a> From<&'a VecStr<'a>> for rustls_slice_str<'a> {
+    fn from(input: &'a VecStr<'a>) -> Self {
+        rustls_slice_str {
+            data: input.0.as_ptr(),
+            len: input.0.len(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// A read-only view on a Rust slice of 16-bit integers in platform endianness.
+///
+/// This is used to pass data from crustls to callback functions provided
+/// by the user of the API.
+/// `len` indicates the number of bytes than can be safely read.
+///
+/// The memory exposed is available as specified by the function
+/// using this in its signature. For instance, when this is a parameter to a
+/// callback, the lifetime will usually be the duration of the callback.
+/// Functions that receive one of these must not retain copies of any of the
+/// pointers beyond the allowed lifetime.
+#[repr(C)]
+pub struct rustls_slice_u16<'a> {
+    pub data: *const u16,
+    pub len: size_t,
+    phantom: PhantomData<&'a [u16]>,
+}
+
+impl<'a> From<&'a [u16]> for rustls_slice_u16<'a> {
+    fn from(s: &[u16]) -> Self {
+        rustls_slice_u16 {
+            data: s.as_ptr() as *const u16,
+            len: s.len() as size_t,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -35,11 +35,11 @@ impl<'a> From<&'a [u8]> for rustls_slice_bytes<'a> {
 
 #[test]
 fn test_rustls_slice_bytes() {
-    let bytes = "abcd".as_bytes();
-    let rsb: rustls_slice_bytes = bytes.into();
+    let bytes = b"abcd";
+    let rsb: rustls_slice_bytes = bytes.as_ref().into();
     unsafe {
-        assert_eq!(*rsb.data, 'a' as u8);
-        assert_eq!(*rsb.data.offset(3), 'd' as u8);
+        assert_eq!(*rsb.data, b'a');
+        assert_eq!(*rsb.data.offset(3), b'd');
         assert_eq!(rsb.len, 4);
     }
 }
@@ -61,8 +61,8 @@ pub struct rustls_slice_slice_bytes<'a> {
     pub inner: &'a [&'a [u8]],
 }
 
-/// Retrieve the nth element from the input slice of slices. If the input
-/// pointer is NULL, returns 0.
+/// Return the length of the outer slice. If the input pointer is NULL,
+/// returns 0.
 #[no_mangle]
 pub extern "C" fn rustls_slice_slice_bytes_len(input: *const rustls_slice_slice_bytes) -> size_t {
     unsafe {
@@ -105,7 +105,7 @@ pub extern "C" fn rustls_slice_slice_bytes_get<'a>(
 
 #[test]
 fn test_rustls_slice_slice_bytes() {
-    let many_bytes = vec!["abcd".as_bytes(), "".as_bytes(), "xyz".as_bytes()];
+    let many_bytes: Vec<&[u8]> = vec![b"abcd", b"", b"xyz"];
     let rssb = rustls_slice_slice_bytes { inner: &many_bytes };
 
     assert_eq!(rustls_slice_slice_bytes_len(&rssb), 3);
@@ -118,15 +118,15 @@ fn test_rustls_slice_slice_bytes() {
     assert_eq!(rustls_slice_slice_bytes_get(&rssb, 3).data, null());
 
     unsafe {
-        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 0).data, 'a' as u8);
+        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 0).data, b'a');
         assert_eq!(
             *rustls_slice_slice_bytes_get(&rssb, 0).data.offset(3),
-            'd' as u8
+            b'd'
         );
-        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 2).data, 'x' as u8);
+        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 2).data, b'x');
         assert_eq!(
             *rustls_slice_slice_bytes_get(&rssb, 2).data.offset(2),
-            'z' as u8
+            b'z'
         );
     }
 }
@@ -206,8 +206,8 @@ pub struct rustls_slice_str<'a> {
     pub inner: &'a [&'a str],
 }
 
-/// Retrieve the nth element from the input slice of slices. If the input
-/// pointer is NULL, returns 0.
+/// Return the length of the outer slice. If the input pointer is NULL,
+/// returns 0.
 #[no_mangle]
 pub extern "C" fn rustls_slice_str_len(input: *const rustls_slice_str) -> size_t {
     unsafe {

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -65,7 +65,7 @@ impl<'a> VecSliceBytes<'a> {
 pub struct rustls_slice_slice_bytes<'a> {
     data: *const rustls_slice_bytes<'a>,
     len: size_t,
-    phantom: PhantomData<&'a [&'a [u8]]>,
+    phantom: PhantomData<&'a [rustls_slice_bytes<'a>]>,
 }
 
 impl<'a> From<&'a VecSliceBytes<'a>> for rustls_slice_slice_bytes<'a> {
@@ -142,7 +142,7 @@ impl<'a> VecStr<'a> {
 pub struct rustls_slice_str<'a> {
     pub data: *const rustls_str<'a>,
     pub len: size_t,
-    phantom: PhantomData<&'a [&'a str]>,
+    phantom: PhantomData<&'a [rustls_str<'a>]>,
 }
 
 impl<'a> From<&'a VecStr<'a>> for rustls_slice_str<'a> {

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -57,7 +57,7 @@ fn test_rustls_slice_bytes() {
 /// callback, the lifetime will usually be the duration of the callback.
 /// Functions that receive one of these must not call its methods beyond the
 /// allowed lifetime.
-pub struct rustls_slice_slice_bytes<'a>{
+pub struct rustls_slice_slice_bytes<'a> {
     pub inner: &'a [&'a [u8]],
 }
 
@@ -105,12 +105,8 @@ pub extern "C" fn rustls_slice_slice_bytes_get<'a>(
 
 #[test]
 fn test_rustls_slice_slice_bytes() {
-    let many_bytes = vec![
-        "abcd".as_bytes(),
-        "".as_bytes(),
-        "xyz".as_bytes(),
-    ];
-    let rssb = rustls_slice_slice_bytes{inner: &many_bytes};
+    let many_bytes = vec!["abcd".as_bytes(), "".as_bytes(), "xyz".as_bytes()];
+    let rssb = rustls_slice_slice_bytes { inner: &many_bytes };
 
     assert_eq!(rustls_slice_slice_bytes_len(&rssb), 3);
 
@@ -123,9 +119,15 @@ fn test_rustls_slice_slice_bytes() {
 
     unsafe {
         assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 0).data, 'a' as u8);
-        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 0).data.offset(3), 'd' as u8);
+        assert_eq!(
+            *rustls_slice_slice_bytes_get(&rssb, 0).data.offset(3),
+            'd' as u8
+        );
         assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 2).data, 'x' as u8);
-        assert_eq!(*rustls_slice_slice_bytes_get(&rssb, 2).data.offset(2), 'z' as u8);
+        assert_eq!(
+            *rustls_slice_slice_bytes_get(&rssb, 2).data.offset(2),
+            'z' as u8
+        );
     }
 }
 
@@ -180,9 +182,9 @@ fn test_rustls_str() {
 
 #[test]
 fn test_rustls_str_rejects_nul() {
-    assert!(matches!(rustls_str::try_from("\0"), Err(NulByte{})));
-    assert!(matches!(rustls_str::try_from("abc\0"), Err(NulByte{})));
-    assert!(matches!(rustls_str::try_from("ab\0cd"), Err(NulByte{})));
+    assert!(matches!(rustls_str::try_from("\0"), Err(NulByte {})));
+    assert!(matches!(rustls_str::try_from("abc\0"), Err(NulByte {})));
+    assert!(matches!(rustls_str::try_from("ab\0cd"), Err(NulByte {})));
 }
 
 /// A read-only view of a slice of multiple Rust `&str`'s (that is, multiple
@@ -200,7 +202,7 @@ fn test_rustls_str_rejects_nul() {
 /// callback, the lifetime will usually be the duration of the callback.
 /// Functions that receive one of these must not call its methods beyond the
 /// allowed lifetime.
-pub struct rustls_slice_str<'a>{
+pub struct rustls_slice_str<'a> {
     pub inner: &'a [&'a str],
 }
 
@@ -246,12 +248,10 @@ pub extern "C" fn rustls_slice_str_get(input: *const rustls_slice_str, n: size_t
 
 #[test]
 fn test_rustls_slice_str() {
-    let many_strings = vec![
-        "abcd",
-        "",
-        "xyz",
-    ];
-    let rss = rustls_slice_str{inner: &many_strings};
+    let many_strings = vec!["abcd", "", "xyz"];
+    let rss = rustls_slice_str {
+        inner: &many_strings,
+    };
 
     assert_eq!(rustls_slice_str_len(&rss), 3);
 
@@ -269,7 +269,6 @@ fn test_rustls_slice_str() {
         assert_eq!(*rustls_slice_str_get(&rss, 2).data.offset(2), 'z' as c_char);
     }
 }
-
 
 /// A read-only view on a Rust slice of 16-bit integers in platform endianness.
 ///


### PR DESCRIPTION
For the basic slice types we need, this introduces `rustls_str`, `rustls_slice_bytes`, and `rustls_slice_u16`. For slices of slices, we have `rustls_slice_str` and `rustls_slice_slice_bytes`. Each of these types have a lifetime parameter that ensures they don't outlive the object they are borrowing from. 

The `str` types have an additional guarantee on top of Rust's guarantee that strings contain UTF-8: They can't contain `\0`. This makes it possible to interpolate them into C strings and compare them against C strings using `strncmp`.

Built off @icing's #50.