### PR TITLE
Remove defensive zeroing

### DIFF
--- a/src/crustls.h
+++ b/src/crustls.h
@@ -225,6 +225,12 @@ enum rustls_result rustls_client_session_write(struct rustls_client_session *ses
  * available have been read, but more bytes may become available after
  * subsequent calls to rustls_client_session_read_tls and
  * rustls_client_session_process_new_packets."
+ *
+ * Subtle note: Even though this function only writes to `buf` and does not
+ * read from it, the memory in `buf` must be initialized before the call (for
+ * Rust-internal reasons). Initializing a buffer once and then using it
+ * multiple times without zeroizing before each call is fine.
+ *
  * https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#method.read
  */
 enum rustls_result rustls_client_session_read(struct rustls_client_session *session,
@@ -251,6 +257,12 @@ enum rustls_result rustls_client_session_read_tls(struct rustls_client_session *
  * Write up to `count` TLS bytes from the ClientSession into `buf`. Those
  * bytes should then be written to a socket. On success, store the number of
  * bytes actually written in *out_n (this maybe less than `count`).
+ *
+ * Subtle note: Even though this function only writes to `buf` and does not
+ * read from it, the memory in `buf` must be initialized before the call (for
+ * Rust-internal reasons). Initializing a buffer once and then using it
+ * multiple times without zeroizing before each call is fine.
+ *
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
  */
 enum rustls_result rustls_client_session_write_tls(struct rustls_client_session *session,
@@ -369,6 +381,12 @@ enum rustls_result rustls_server_session_write(struct rustls_server_session *ses
  * available have been read, but more bytes may become available after
  * subsequent calls to rustls_server_session_read_tls and
  * rustls_server_session_process_new_packets."
+ *
+ * Subtle note: Even though this function only writes to `buf` and does not
+ * read from it, the memory in `buf` must be initialized before the call (for
+ * Rust-internal reasons). Initializing a buffer once and then using it
+ * multiple times without zeroizing before each call is fine.
+ *
  * https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.read
  */
 enum rustls_result rustls_server_session_read(struct rustls_server_session *session,
@@ -395,6 +413,12 @@ enum rustls_result rustls_server_session_read_tls(struct rustls_server_session *
  * Write up to `count` TLS bytes from the ServerSession into `buf`. Those
  * bytes should then be written to a socket. On success, store the number of
  * bytes actually written in *out_n (this maybe less than `count`).
+ *
+ * Subtle note: Even though this function only writes to `buf` and does not
+ * read from it, the memory in `buf` must be initialized before the call (for
+ * Rust-internal reasons). Initializing a buffer once and then using it
+ * multiple times without zeroizing before each call is fine.
+ *
  * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
  */
 enum rustls_result rustls_server_session_write_tls(struct rustls_server_session *session,

--- a/src/server.rs
+++ b/src/server.rs
@@ -306,6 +306,12 @@ pub extern "C" fn rustls_server_session_write(
 /// available have been read, but more bytes may become available after
 /// subsequent calls to rustls_server_session_read_tls and
 /// rustls_server_session_process_new_packets."
+///
+/// Subtle note: Even though this function only writes to `buf` and does not
+/// read from it, the memory in `buf` must be initialized before the call (for
+/// Rust-internal reasons). Initializing a buffer once and then using it
+/// multiple times without zeroizing before each call is fine.
+///
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ServerSession.html#method.read
 #[no_mangle]
 pub extern "C" fn rustls_server_session_read(
@@ -328,12 +334,6 @@ pub extern "C" fn rustls_server_session_read(
                 None => return NullParameter,
             }
         };
-        // Since it's *possible* for a Read impl to consume the possibly-uninitialized memory from buf,
-        // zero it out just in case. TODO: use Initializer once it's stabilized.
-        // https://doc.rust-lang.org/nightly/std/io/trait.Read.html#method.initializer
-        for c in read_buf.iter_mut() {
-            *c = 0;
-        }
         let n_read: usize = match session.read(read_buf) {
             Ok(n) => n,
             // The CloseNotify TLS alert is benign, but rustls returns it as an Error. See comment on
@@ -392,6 +392,12 @@ pub extern "C" fn rustls_server_session_read_tls(
 /// Write up to `count` TLS bytes from the ServerSession into `buf`. Those
 /// bytes should then be written to a socket. On success, store the number of
 /// bytes actually written in *out_n (this maybe less than `count`).
+///
+/// Subtle note: Even though this function only writes to `buf` and does not
+/// read from it, the memory in `buf` must be initialized before the call (for
+/// Rust-internal reasons). Initializing a buffer once and then using it
+/// multiple times without zeroizing before each call is fine.
+///
 /// https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.write_tls
 #[no_mangle]
 pub extern "C" fn rustls_server_session_write_tls(


### PR DESCRIPTION
In favor of asking the C caller to initialize memory once before calling
functions that turn buffers into slices. The previous behavior had a
high performance cost.

This code was originally intended to avoid undefined behavior because:

https://doc.rust-lang.org/std/slice/fn.from_raw_parts_mut.html#safety

> Behavior is undefined if any of the following conditions are violated:
> ...
> data must point to len consecutive properly initialized values of type T.

However, we were zeroing the memory _after_ constructing the slice, so
it was ineffective. We could change that to ensure the memory is
initialized _before_ constructing the slice, but we want better
performance anyhow, so we do this.

Fixes #55