### PR TITLE
Do some tweaks and cleanups

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -1,18 +1,17 @@
+use libc::{c_char, size_t};
+use std::io::Cursor;
+use std::os::raw::c_ushort;
+use std::sync::Arc;
 use std::{cmp::min, slice};
+
+use rustls::sign::CertifiedKey;
+use rustls::{Certificate, PrivateKey};
+use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 
 use crate::error::rustls_result;
 use crate::{
     ffi_panic_boundary, ffi_panic_boundary_generic, ffi_panic_boundary_unit, try_ref_from_ptr,
 };
-use libc::{c_char, size_t};
-use std::io::Cursor;
-use std::os::raw::c_ushort;
-use std::sync::Arc;
-
-use rustls::{Certificate, PrivateKey};
-use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
-
-use rustls::sign::CertifiedKey;
 use rustls_result::NullParameter;
 
 /// All SignatureScheme currently defined in rustls.
@@ -49,12 +48,11 @@ fn signature_scheme_name(n: u16) -> String {
 
 /// Get the name of a SignatureScheme, represented by the `scheme` short value,
 /// if known by the rustls library. For unknown schemes, this returns a string
-/// with the scheme value in hex notation.
-/// Mainly useful for debugging output.
+/// with the scheme value in hex notation. Mainly useful for debugging output.
+///
 /// The caller provides `buf` for holding the string and gives its size as `len`
 /// bytes. On return `out_n` carries the number of bytes copied into `buf`. The
 /// `buf` is not NUL-terminated.
-///
 #[no_mangle]
 pub extern "C" fn rustls_cipher_get_signature_scheme_name(
     scheme: c_ushort,
@@ -64,28 +62,23 @@ pub extern "C" fn rustls_cipher_get_signature_scheme_name(
 ) {
     ffi_panic_boundary_unit! {
         let write_buf: &mut [u8] = unsafe {
-            let out_n: &mut size_t = match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return,
-            };
-            *out_n = 0;
             if buf.is_null() {
                 return;
             }
             slice::from_raw_parts_mut(buf as *mut u8, len as usize)
         };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t, ());
         let name = signature_scheme_name(scheme);
         let len: usize = min(write_buf.len() - 1, name.len());
         write_buf[..len].copy_from_slice(&name.as_bytes()[..len]);
-        unsafe {
-            *out_n = len;
-        }
+        *out_n = len;
     }
 }
 
-/// The complete chain of certificates plus private key for
-/// being certified against someones list of trust anchors (commonly
-/// called root store). Corresponds to `CertifiedKey` in the Rust API.
+/// The complete chain of certificates to send during a TLS handshake,
+/// plus a private key that matches the end-entity (leaf) certificate.
+/// Corresponds to `CertifiedKey` in the Rust API.
+/// https://docs.rs/rustls/0.19.0/rustls/sign/struct.CertifiedKey.html
 pub struct rustls_certified_key {
     // We use the opaque struct pattern to tell C about our types without
     // telling them what's inside.
@@ -93,6 +86,21 @@ pub struct rustls_certified_key {
     _private: [u8; 0],
 }
 
+/// Build a `rustls_certified_key` from a certificate chain and a private key.
+/// `cert_chain` must point to an array of `cert_chain_len` bytes, containing
+/// a series of PEM-encoded certificates, with the end-entity (leaf)
+/// certificate first.
+///
+/// `private_key` must point to an array of `private_key_len` bytes, containing
+/// a PEM-encoded private key in either PKCS#1 or PKCS#8 format.
+///
+/// On success, this writes a pointer to the newly created
+/// `rustls_certified_key` in `certified_key_out`. That pointer must later
+/// be freed with `rustls_certified_key_free` to avoid memory leaks. Note that
+/// internally, this is an atomically reference-counted pointer, so even after
+/// the original caller has called `rustls_certified_key_free`, other objects
+/// may retain a pointer to the object. The memory will be freed when all
+/// references are gone.
 #[no_mangle]
 pub extern "C" fn rustls_certified_key_build(
     cert_chain: *const u8,
@@ -102,14 +110,15 @@ pub extern "C" fn rustls_certified_key_build(
     certified_key_out: *mut *const rustls_certified_key,
 ) -> rustls_result {
     ffi_panic_boundary! {
+        let certified_key_out: &mut *const rustls_certified_key =
+            try_ref_from_ptr!(certified_key_out, &mut *const rustls_certified_key);
         let certified_key = match certified_key_build(
             cert_chain, cert_chain_len, private_key, private_key_len) {
             Ok(key) => Box::new(key),
             Err(rr) => return rr,
         };
-        unsafe {
-            *certified_key_out = Arc::into_raw(Arc::new(*certified_key)) as *const _;
-        }
+        let certified_key = Arc::into_raw(Arc::new(*certified_key)) as *const _;
+        *certified_key_out = certified_key;
         return rustls_result::Ok
     }
 }
@@ -127,19 +136,11 @@ pub extern "C" fn rustls_certified_key_free(config: *const rustls_certified_key)
         // To free the certified_key, we reconstruct the Arc. It should have a refcount of 1,
         // representing the C code's copy. When it drops, that refcount will go down to 0
         // and the inner ServerConfig will be dropped.
-        let arc: Arc<CertifiedKey> = unsafe { Arc::from_raw(key) };
-        let strong_count = Arc::strong_count(&arc);
-        if strong_count < 1 {
-            eprintln!(
-                "rustls_certified_key_free: invariant failed: arc.strong_count was < 1: {}. \
-                You must not free the same certified_key multiple times.",
-                strong_count
-            );
-        }
+        unsafe { drop(Arc::from_raw(key)) };
     }
 }
 
-pub(crate) fn certified_key_build(
+fn certified_key_build(
     cert_chain: *const u8,
     cert_chain_len: size_t,
     private_key: *const u8,

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -61,10 +61,10 @@ pub extern "C" fn rustls_cipher_get_signature_scheme_name(
     out_n: *mut size_t,
 ) {
     ffi_panic_boundary_unit! {
+        if buf.is_null() {
+            return;
+        }
         let write_buf: &mut [u8] = unsafe {
-            if buf.is_null() {
-                return;
-            }
             slice::from_raw_parts_mut(buf as *mut u8, len as usize)
         };
         let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t, ());
@@ -87,11 +87,11 @@ pub struct rustls_certified_key {
 }
 
 /// Build a `rustls_certified_key` from a certificate chain and a private key.
-/// `cert_chain` must point to an array of `cert_chain_len` bytes, containing
+/// `cert_chain` must point to a buffer of `cert_chain_len` bytes, containing
 /// a series of PEM-encoded certificates, with the end-entity (leaf)
 /// certificate first.
 ///
-/// `private_key` must point to an array of `private_key_len` bytes, containing
+/// `private_key` must point to a buffer of `private_key_len` bytes, containing
 /// a PEM-encoded private key in either PKCS#1 or PKCS#8 format.
 ///
 /// On success, this writes a pointer to the newly created

--- a/src/client.rs
+++ b/src/client.rs
@@ -483,12 +483,7 @@ pub extern "C" fn rustls_client_session_read(
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n = unsafe {
-            match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
-            }
-        };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
         let n_read: usize = match session.read(read_buf) {
             Ok(n) => n,
             // The CloseNotify TLS alert is benign, but rustls returns it as an Error. See comment on
@@ -528,12 +523,7 @@ pub extern "C" fn rustls_client_session_read_tls(
             }
             slice::from_raw_parts(buf, count as usize)
         };
-        let out_n = unsafe {
-            match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
-            }
-        };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
         let mut cursor = Cursor::new(input_buf);
         let n_read: usize = match session.read_tls(&mut cursor) {
             Ok(n) => n,
@@ -569,12 +559,7 @@ pub extern "C" fn rustls_client_session_write_tls(
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n = unsafe {
-            match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
-            }
-        };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
         let n_written: usize = match session.write_tls(&mut output_buf) {
             Ok(n) => n,
             Err(_) => return rustls_result::Io,

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -321,11 +321,11 @@ void rustls_cipher_get_signature_scheme_name(unsigned short scheme,
 
 /**
  * Build a `rustls_certified_key` from a certificate chain and a private key.
- * `cert_chain` must point to an array of `cert_chain_len` bytes, containing
+ * `cert_chain` must point to a buffer of `cert_chain_len` bytes, containing
  * a series of PEM-encoded certificates, with the end-entity (leaf)
  * certificate first.
  *
- * `private_key` must point to an array of `private_key_len` bytes, containing
+ * `private_key` must point to a buffer of `private_key_len` bytes, containing
  * a PEM-encoded private key in either PKCS#1 or PKCS#8 format.
  *
  * On success, this writes a pointer to the newly created
@@ -605,7 +605,7 @@ enum rustls_result rustls_server_config_builder_set_ignore_client_order(struct r
 /**
  * Set the ALPN protocol list to the given protocols. `protocols` must point
  * to a buffer of `rustls_slice_bytes` (built by the caller) with `len`
- * elements. Each element of th buffer must point to a slice of bytes that
+ * elements. Each element of the buffer must point to a slice of bytes that
  * contains a single ALPN protocol from
  * https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids.
  *

--- a/src/server.rs
+++ b/src/server.rs
@@ -107,7 +107,7 @@ pub extern "C" fn rustls_server_config_builder_set_ignore_client_order(
 
 /// Set the ALPN protocol list to the given protocols. `protocols` must point
 /// to a buffer of `rustls_slice_bytes` (built by the caller) with `len`
-/// elements. Each element of th buffer must point to a slice of bytes that
+/// elements. Each element of the buffer must point to a slice of bytes that
 /// contains a single ALPN protocol from
 /// https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids.
 ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,7 +84,7 @@ pub extern "C" fn rustls_server_config_builder_from_config(
     config: *const rustls_server_config,
 ) -> *mut rustls_server_config_builder {
     ffi_panic_boundary_ptr! {
-        let config: &ServerConfig = try_ref_from_ptr!(config, & ServerConfig, null_mut());
+        let config: &ServerConfig = try_ref_from_ptr!(config, &ServerConfig, null_mut());
         Box::into_raw(Box::new(config.clone())) as *mut _
     }
 }
@@ -105,6 +105,16 @@ pub extern "C" fn rustls_server_config_builder_set_ignore_client_order(
     }
 }
 
+/// Set the ALPN protocol list to the given protocols. `protocols` must point
+/// to a buffer of `rustls_slice_bytes` (built by the caller) with `len`
+/// elements. Each element of th buffer must point to a slice of bytes that
+/// contains a single ALPN protocol from
+/// https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids.
+///
+/// This function makes a copy of the data in `protocols` and does not retain
+/// any pointers, so the caller can free the pointed-to memory after calling.
+///
+/// https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html#method.set_protocols
 #[no_mangle]
 pub extern "C" fn rustls_server_config_builder_set_protocols(
     builder: *mut rustls_server_config_builder,
@@ -117,7 +127,7 @@ pub extern "C" fn rustls_server_config_builder_set_protocols(
             if protocols.is_null() {
                 return NullParameter;
             }
-                slice::from_raw_parts(protocols, len)
+            slice::from_raw_parts(protocols, len)
         };
 
         let mut vv: Vec<Vec<u8>> = Vec::new();
@@ -137,8 +147,8 @@ pub extern "C" fn rustls_server_config_builder_set_protocols(
 
 /// Provide the configuration a list of certificates where the session
 /// will select the first one that is compatible with the client's signature
-/// verification capabilities. Servers that want to support ECDSA and RSA certificates
-/// will want the ECSDA to go first in the list.
+/// verification capabilities. Servers that want to support both ECDSA and
+/// RSA certificates will want the ECSDA to go first in the list.
 ///
 /// The built configuration will keep a reference to all certified keys
 /// provided. The client may `rustls_certified_key_free()` afterwards
@@ -164,6 +174,8 @@ pub extern "C" fn rustls_server_config_builder_set_certified_keys(
         };
         let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
         for &key_ptr in keys_ptrs {
+            let key_ptr: &CertifiedKey = try_ref_from_ptr!(key_ptr,
+                &CertifiedKey);
             let certified_key: Arc<CertifiedKey> = unsafe {
                 match (key_ptr as *const CertifiedKey).as_ref() {
                     Some(c) => arc_with_incref_from_raw(c),
@@ -204,15 +216,7 @@ pub extern "C" fn rustls_server_config_free(config: *const rustls_server_config)
         // To free the server_config, we reconstruct the Arc. It should have a refcount of 1,
         // representing the C code's copy. When it drops, that refcount will go down to 0
         // and the inner ServerConfig will be dropped.
-        let arc: Arc<ServerConfig> = unsafe { Arc::from_raw(config) };
-        let strong_count = Arc::strong_count(&arc);
-        if strong_count < 1 {
-            eprintln!(
-                "rustls_server_config_free: invariant failed: arc.strong_count was < 1: {}. \
-                You must not free the same server_config multiple times.",
-                strong_count
-            );
-        }
+        unsafe { drop(Arc::from_raw(config)) };
     }
 }
 
@@ -371,12 +375,7 @@ pub extern "C" fn rustls_server_session_read(
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n = unsafe {
-            match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
-            }
-        };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
         let n_read: usize = match session.read(read_buf) {
             Ok(n) => n,
             // The CloseNotify TLS alert is benign, but rustls returns it as an Error. See comment on
@@ -416,12 +415,7 @@ pub extern "C" fn rustls_server_session_read_tls(
             }
             slice::from_raw_parts(buf, count as usize)
         };
-        let out_n = unsafe {
-            match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
-            }
-        };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
         let mut cursor = Cursor::new(input_buf);
         let n_read: usize = match session.read_tls(&mut cursor) {
             Ok(n) => n,
@@ -457,12 +451,7 @@ pub extern "C" fn rustls_server_session_write_tls(
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n = unsafe {
-            match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
-            }
-        };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
         let n_written: usize = match session.write_tls(&mut output_buf) {
             Ok(n) => n,
             Err(_) => return rustls_result::Io,
@@ -489,16 +478,12 @@ pub extern "C" fn rustls_server_session_get_sni_hostname(
     ffi_panic_boundary! {
         let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, NullParameter);
         let write_buf: &mut [u8] = unsafe {
-            let out_n: &mut size_t = match out_n.as_mut() {
-                Some(out_n) => out_n,
-                None => return NullParameter,
-            };
-            *out_n = 0;
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts_mut(buf as *mut u8, count as usize)
         };
+        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
         let sni_hostname = match session.get_sni_hostname() {
             Some(sni_hostname) => sni_hostname,
             None => {
@@ -510,15 +495,13 @@ pub extern "C" fn rustls_server_session_get_sni_hostname(
             return rustls_result::InsufficientSize;
         }
         write_buf[..len].copy_from_slice(&sni_hostname.as_bytes());
-        unsafe {
-            *out_n = len;
-        }
+        *out_n = len;
         rustls_result::Ok
     }
 }
 
-/// Choose the server certificate to be used for a session.
-/// Will pick the first CertfiedKey available that is suitable for
+/// Choose the server certificate to be used for a session based on certificate
+/// type. Will pick the first CertfiedKey available that is suitable for
 /// the SignatureSchemes supported by the client.
 struct ResolvesServerCertFromChoices {
     choices: Vec<Arc<CertifiedKey>>,
@@ -630,7 +613,7 @@ impl ResolvesServerCert for ClientHelloResolver {
             .collect();
         // Unwrap the Option. None becomes an empty slice.
         let alpn: &[&[u8]] = client_hello.alpn().unwrap_or(&[]);
-        let alpn: rustls_slice_slice_bytes = rustls_slice_slice_bytes { inner: alpn };
+        let alpn = rustls_slice_slice_bytes { inner: alpn };
         let signature_schemes: rustls_slice_u16 = (&*mapped_sigs).into();
         let hello = rustls_client_hello {
             sni_name,
@@ -638,7 +621,7 @@ impl ResolvesServerCert for ClientHelloResolver {
             alpn: &alpn,
         };
         let cb = self.callback;
-        let key_ptr = unsafe { cb(self.userdata, &hello) };
+        let key_ptr: *const rustls_certified_key = unsafe { cb(self.userdata, &hello) };
         let certified_key: &CertifiedKey = try_ref_from_ptr!(key_ptr, &CertifiedKey, None);
         Some(certified_key.clone())
     }


### PR DESCRIPTION
Order imports as: std, third-party, crate.

Use `try_ref_from_ptr!` to turn `out_n`'s into refs. This moves unsafe blocks from later in the function to earlier in the function, closer to where their safety properties are checked. Also, remove pre-emptive zeroing of `out_n`'s. According to the conventions listed in our README, there are no partial successes or partial failures, so we shouldn't write to `out_n` if we early-return.

Remove `strong_count < 1` checks on Arc. Follow-up from #32.

Add some missing comments and fix some formatting.