### PR TITLE
session storage in the API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -579,6 +579,9 @@ pub extern "C" fn rustls_client_session_write_tls(
 /// keys and values are highly sensitive data, containing enough information
 /// to break the security of the sessions involved.
 ///
+/// `userdata` must live as long as the config object and any sessions
+/// or other config created from that config object.
+///
 #[no_mangle]
 pub extern "C" fn rustls_client_config_builder_set_persistence(
     builder: *mut rustls_client_config_builder,

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -238,6 +238,55 @@ typedef enum rustls_result (*rustls_verify_server_cert_callback)(rustls_verify_s
 /**
  * Any context information the callback will receive when invoked.
  */
+typedef void *rustls_session_store_userdata;
+
+/**
+ * Prototype of a callback that can be installed by the application at the
+ * `rustls_server_config` or `rustls_client_config`. This callback will be
+ * invoked by a TLS session when looking up the data for a TLS session id.
+ * `userdata` will be supplied as provided when registering the callback.
+ *
+ * The `buf` points to a buffer of `count` consecutive bytes where the
+ * callback is expected to copy the result to. The number of copied bytes
+ * needs to be written to `out_n`.
+ *
+ * If the value to copy is larger than `count`, the callback should never
+ * do a partial copy but instead remove the value from its store and
+ * act as if it was never found.
+ *
+ * The callback should return != 0 to indicate that a value was retrieved
+ * and written in its entirety into `buf`.
+ *
+ * When `remove_after` is != 0, the returned data needs to be removed
+ * from the store.
+ *
+ * NOTE: the passed in `key` and `buf` are only availabe during the
+ * callback invocation.
+ * NOTE: callbacks used in several sessions via a common config
+ * must be implemented thread-safe.
+ */
+typedef int (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, uint8_t *buf, size_t count, int remove_after, size_t *out_n);
+
+/**
+ * Prototype of a callback that can be installed by the application at the
+ * `rustls_server_config` or `rustls_client_config`. This callback will be
+ * invoked by a TLS session when a TLS session has been created and an id
+ * for later use is handed to the client/has been received from the server.
+ * `userdata` will be supplied as provided when registering the callback.
+ *
+ * The callback should return != 0 to indicate that the value has been
+ * successfully persisted in its store.
+ *
+ * NOTE: the passed in `key` and `val` are only availabe during the
+ * callback invocation.
+ * NOTE: callbacks used in several sessions via a common config
+ * must be implemented thread-safe.
+ */
+typedef int (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
+
+/**
+ * Any context information the callback will receive when invoked.
+ */
 typedef void *rustls_client_hello_userdata;
 
 /**
@@ -297,55 +346,6 @@ typedef struct rustls_client_hello {
  * the rustls library is re-evaluating their current approach to client hello handling.
  */
 typedef const struct rustls_certified_key *(*rustls_client_hello_callback)(rustls_client_hello_userdata userdata, const struct rustls_client_hello *hello);
-
-/**
- * Any context information the callback will receive when invoked.
- */
-typedef void *rustls_session_store_userdata;
-
-/**
- * Prototype of a callback that can be installed by the application at the
- * `rustls_server_config` or `rustls_client_config`. This callback will be
- * invoked by a TLS session when looking up the data for a TLS session id.
- * `userdata` will be supplied as provided when registering the callback.
- *
- * The `buf` points to a buffer of `count` consecutive bytes where the
- * callback is expected to copy the result to. The number of copied bytes
- * needs to be written to `out_n`.
- *
- * If the value to copy is larger than `count`, the callback should never
- * do a partial copy but instead remove the value from its store and
- * act as if it was never found.
- *
- * The callback should return != 0 to indicate that a value was retrieved
- * and written in its entirety into `buf`.
- *
- * When `remove_after` is != 0, the returned data needs to be removed
- * from the store.
- *
- * NOTE: the passed in `key` and `buf` are only availabe during the
- * callback invocation.
- * NOTE: callbacks used in several sessions via a common config
- * must be implemented thread-safe.
- */
-typedef int (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, uint8_t *buf, size_t count, int remove_after, size_t *out_n);
-
-/**
- * Prototype of a callback that can be installed by the application at the
- * `rustls_server_config` or `rustls_client_config`. This callback will be
- * invoked by a TLS session when a TLS session has been created and an id
- * for later use is handed to the client/has been received from the server.
- * `userdata` will be supplied as provided when registering the callback.
- *
- * The callback should return != 0 to indicate that the value has been
- * successfully persisted in its store.
- *
- * NOTE: the passed in `key` and `val` are only availabe during the
- * callback invocation.
- * NOTE: callbacks used in several sessions via a common config
- * must be implemented thread-safe.
- */
-typedef int (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
 
 /**
  * Write the version of the crustls C bindings and rustls itself into the
@@ -578,6 +578,17 @@ enum rustls_result rustls_client_session_write_tls(struct rustls_client_session 
                                                    uint8_t *buf,
                                                    size_t count,
                                                    size_t *out_n);
+
+/**
+ * Register callbacks for persistence of TLS session IDs and secrets. Both
+ * keys and values are highly sensitive data, containing enough information
+ * to break the security of the sessions involved.
+ *
+ */
+enum rustls_result rustls_client_config_builder_set_persistence(struct rustls_client_config_builder *builder,
+                                                                rustls_session_store_userdata userdata,
+                                                                rustls_session_store_get_callback get_cb,
+                                                                rustls_session_store_put_callback put_cb);
 
 /**
  * After a rustls_client_session method returns an error, you may call

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -15,6 +15,7 @@ typedef enum rustls_result {
   RUSTLS_RESULT_CERTIFICATE_PARSE_ERROR = 7005,
   RUSTLS_RESULT_PRIVATE_KEY_PARSE_ERROR = 7006,
   RUSTLS_RESULT_INSUFFICIENT_SIZE = 7007,
+  RUSTLS_RESULT_NOT_FOUND = 7008,
   RUSTLS_RESULT_CORRUPT_MESSAGE = 7100,
   RUSTLS_RESULT_NO_CERTIFICATES_PRESENTED = 7101,
   RUSTLS_RESULT_DECRYPT_ERROR = 7102,
@@ -246,9 +247,10 @@ typedef void *rustls_session_store_userdata;
  * invoked by a TLS session when looking up the data for a TLS session id.
  * `userdata` will be supplied as provided when registering the callback.
  *
- * The `buf` points to a buffer of `count` consecutive bytes where the
+ * The `buf` points to `count` consecutive bytes where the
  * callback is expected to copy the result to. The number of copied bytes
- * needs to be written to `out_n`.
+ * needs to be written to `out_n`. The callback should not read any
+ * data from `buf`.
  *
  * If the value to copy is larger than `count`, the callback should never
  * do a partial copy but instead remove the value from its store and
@@ -260,12 +262,12 @@ typedef void *rustls_session_store_userdata;
  * When `remove_after` is != 0, the returned data needs to be removed
  * from the store.
  *
- * NOTE: the passed in `key` and `buf` are only availabe during the
+ * NOTE: the passed in `key` and `buf` are only available during the
  * callback invocation.
  * NOTE: callbacks used in several sessions via a common config
  * must be implemented thread-safe.
  */
-typedef int (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, uint8_t *buf, size_t count, int remove_after, size_t *out_n);
+typedef enum rustls_result (*rustls_session_store_get_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, int remove_after, uint8_t *buf, size_t count, size_t *out_n);
 
 /**
  * Prototype of a callback that can be installed by the application at the
@@ -277,12 +279,12 @@ typedef int (*rustls_session_store_get_callback)(rustls_session_store_userdata u
  * The callback should return != 0 to indicate that the value has been
  * successfully persisted in its store.
  *
- * NOTE: the passed in `key` and `val` are only availabe during the
+ * NOTE: the passed in `key` and `val` are only available during the
  * callback invocation.
  * NOTE: callbacks used in several sessions via a common config
  * must be implemented thread-safe.
  */
-typedef int (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
+typedef enum rustls_result (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
 
 /**
  * Any context information the callback will receive when invoked.
@@ -339,8 +341,13 @@ typedef struct rustls_client_hello {
  * `hello` gives the value of the available client announcements, as interpreted
  * by rustls. See the definition of `rustls_client_hello` for details.
  *
- * NOTE: the passed in `hello` and all its values are only availabe during the
- * callback invocations.
+ * NOTE:
+ * - the passed in `hello` and all its values are only available during the
+ *   callback invocations.
+ * - the passed callback function must be implemented thread-safe, unless
+ *   there is only a single config and session where it is installed.
+ * - `userdata` must live as long as the config object and any sessions
+ *   or other config created from that config object.
  *
  * EXPERIMENTAL: this feature of crustls is likely to change in the future, as
  * the rustls library is re-evaluating their current approach to client hello handling.
@@ -580,9 +587,13 @@ enum rustls_result rustls_client_session_write_tls(struct rustls_client_session 
                                                    size_t *out_n);
 
 /**
- * Register callbacks for persistence of TLS session IDs and secrets. Both
+ * Register callbacks for persistence of TLS session data. This means either
+ * session IDs (TLSv1.2) or . Both
  * keys and values are highly sensitive data, containing enough information
  * to break the security of the sessions involved.
+ *
+ * `userdata` must live as long as the config object and any sessions
+ * or other config created from that config object.
  *
  */
 enum rustls_result rustls_client_config_builder_set_persistence(struct rustls_client_config_builder *builder,
@@ -846,6 +857,8 @@ enum rustls_result rustls_server_config_builder_set_hello_callback(struct rustls
  * keys and values are highly sensitive data, containing enough information
  * to break the security of the sessions involved.
  *
+ * `userdata` must live as long as the config object and any sessions
+ * or other config created from that config object.
  */
 enum rustls_result rustls_server_config_builder_set_persistence(struct rustls_server_config_builder *builder,
                                                                 rustls_session_store_userdata userdata,

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,7 @@ pub extern "C" fn rustls_result_is_cert_error(result: rustls_result) -> bool {
     }
 }
 
+#[allow(dead_code)]
 #[repr(C)]
 pub enum rustls_result {
     Ok = 7000,
@@ -55,6 +56,7 @@ pub enum rustls_result {
     CertificateParseError = 7005,
     PrivateKeyParseError = 7006,
     InsufficientSize = 7007,
+    NotFound = 7008,
 
     // From https://docs.rs/rustls/0.19.0/rustls/enum.TLSError.html
     CorruptMessage = 7100,
@@ -271,6 +273,7 @@ pub(crate) fn result_to_tlserror(input: &rustls_result) -> Either {
         CertificateParseError => return Either::String("error parsing certificate".to_string()),
         PrivateKeyParseError => return Either::String("error parsing private key".to_string()),
         InsufficientSize => return Either::String("provided buffer is of insufficient size".to_string()),
+        NotFound => return Either::String("the item was not found".to_string()),
 
         // These variants correspond to a TLSError variant with a field,
         // where generating an arbitrary field would produce a confusing error
@@ -294,6 +297,7 @@ pub(crate) fn result_to_tlserror(input: &rustls_result) -> Either {
         CertificateParseError => unreachable!(),
         PrivateKeyParseError => unreachable!(),
         InsufficientSize => unreachable!(),
+        NotFound => unreachable!(),
 
         InappropriateMessage => unreachable!(),
         InappropriateHandshakeMessage => unreachable!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod client;
 mod error;
 mod rslice;
 mod server;
+mod session;
 
 // Keep in sync with Cargo.toml.
 const RUSTLS_CRATE_VERSION: &str = "0.19.0";

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,156 @@
+use crate::rslice::rustls_slice_bytes;
+use libc::size_t;
+use std::ffi::c_void;
+use std::os::raw::c_int;
+
+/// Any context information the callback will receive when invoked.
+pub type rustls_session_store_userdata = *mut c_void;
+
+/// Prototype of a callback that can be installed by the application at the
+/// `rustls_server_config` or `rustls_client_config`. This callback will be
+/// invoked by a TLS session when looking up the data for a TLS session id.
+/// `userdata` will be supplied as provided when registering the callback.
+///
+/// The `buf` points to a buffer of `count` consecutive bytes where the
+/// callback is expected to copy the result to. The number of copied bytes
+/// needs to be written to `out_n`.
+///
+/// If the value to copy is larger than `count`, the callback should never
+/// do a partial copy but instead remove the value from its store and
+/// act as if it was never found.
+///
+/// The callback should return != 0 to indicate that a value was retrieved
+/// and written in its entirety into `buf`.
+///
+/// When `remove_after` is != 0, the returned data needs to be removed
+/// from the store.
+///
+/// NOTE: the passed in `key` and `buf` are only availabe during the
+/// callback invocation.
+/// NOTE: callbacks used in several sessions via a common config
+/// must be implemented thread-safe.
+pub type rustls_session_store_get_callback = Option<
+    unsafe extern "C" fn(
+        userdata: rustls_session_store_userdata,
+        key: *const rustls_slice_bytes,
+        buf: *mut u8,
+        count: size_t,
+        remove_after: c_int,
+        out_n: *mut size_t,
+    ) -> c_int,
+>;
+
+pub(crate) type SessionStoreGetCallback = unsafe extern "C" fn(
+    userdata: rustls_session_store_userdata,
+    key: *const rustls_slice_bytes,
+    buf: *mut u8,
+    count: size_t,
+    remove_after: c_int,
+    out_n: *mut size_t,
+) -> c_int;
+
+/// Prototype of a callback that can be installed by the application at the
+/// `rustls_server_config` or `rustls_client_config`. This callback will be
+/// invoked by a TLS session when a TLS session has been created and an id
+/// for later use is handed to the client/has been received from the server.
+/// `userdata` will be supplied as provided when registering the callback.
+///
+/// The callback should return != 0 to indicate that the value has been
+/// successfully persisted in its store.
+///
+/// NOTE: the passed in `key` and `val` are only availabe during the
+/// callback invocation.
+/// NOTE: callbacks used in several sessions via a common config
+/// must be implemented thread-safe.
+pub type rustls_session_store_put_callback = Option<
+    unsafe extern "C" fn(
+        userdata: rustls_session_store_userdata,
+        key: *const rustls_slice_bytes,
+        val: *const rustls_slice_bytes,
+    ) -> c_int,
+>;
+
+pub(crate) type SessionStorePutCallback = unsafe extern "C" fn(
+    userdata: rustls_session_store_userdata,
+    key: *const rustls_slice_bytes,
+    val: *const rustls_slice_bytes,
+) -> c_int;
+
+pub(crate) struct SessionStoreBroker {
+    pub userdata: rustls_session_store_userdata,
+    pub get_cb: SessionStoreGetCallback,
+    pub put_cb: SessionStorePutCallback,
+}
+
+impl SessionStoreBroker {
+    pub fn new(
+        userdata: rustls_session_store_userdata,
+        get_cb: SessionStoreGetCallback,
+        put_cb: SessionStorePutCallback,
+    ) -> Self {
+        SessionStoreBroker {
+            userdata,
+            get_cb,
+            put_cb,
+        }
+    }
+
+    fn retrieve(&self, key: &[u8], remove: bool) -> Option<Vec<u8>> {
+        let key: rustls_slice_bytes = key.into();
+        let mut data: Vec<u8> = Vec::with_capacity(8192);
+        let buffer = data.as_mut_slice();
+        let mut out_n: size_t = 0;
+        unsafe {
+            let cb = self.get_cb;
+            if cb(
+                self.userdata,
+                &key,
+                buffer.as_mut_ptr(),
+                buffer.len(),
+                remove as c_int,
+                &mut out_n,
+            ) != 0
+            {
+                data.set_len(out_n);
+                return Some(data);
+            }
+            None
+        }
+    }
+
+    fn store(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
+        let key: rustls_slice_bytes = key.as_slice().into();
+        let value: rustls_slice_bytes = value.as_slice().into();
+        unsafe {
+            let cb = self.put_cb;
+            cb(self.userdata, &key, &value) != 0
+        }
+    }
+}
+
+impl rustls::StoresServerSessions for SessionStoreBroker {
+    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
+        self.store(key, value)
+    }
+
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        return self.retrieve(key, false);
+    }
+
+    fn take(&self, key: &[u8]) -> Option<Vec<u8>> {
+        return self.retrieve(key, true);
+    }
+}
+
+impl rustls::StoresClientSessions for SessionStoreBroker {
+    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
+        self.store(key, value)
+    }
+
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        return self.retrieve(key, false);
+    }
+}
+
+unsafe impl Sync for SessionStoreBroker {}
+unsafe impl Send for SessionStoreBroker {}


### PR DESCRIPTION
Adding session storage handling from `rustls` to the API.

The 3 traits functions for server storage are mapped into 2 C callbacks and used also for the client version. There is a `SessionStoreBroker` which can be used in both configs.

This is the first time we have the C side copying bytes into a Rust provided buffer, but I see no better way to handle it in this scenario. The lookup happens on every new connection and needs to be thread safe. A global buffer is therefore out of the question.

I added test cases for the server side in `mod_tls`.