### PR TITLE
Pass through close_notify alerts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 #![crate_type = "staticlib"]
 #![allow(non_camel_case_types)]
 use libc::{c_char, size_t};
-use std::{cmp::min, sync::Arc};
-use std::{mem, slice};
+use std::cmp::min;
+use std::io::ErrorKind::ConnectionAborted;
+use std::sync::Arc;
+use std::{io, mem, slice};
 
 mod cipher;
 mod client;
@@ -144,4 +146,8 @@ unsafe fn arc_with_incref_from_raw<T>(v: *const T) -> Arc<T> {
     let val = Arc::clone(&r);
     mem::forget(r);
     val
+}
+
+pub(crate) fn is_close_notify(e: &io::Error) -> bool {
+    e.kind() == ConnectionAborted && e.to_string().contains("CloseNotify")
 }

--- a/src/main.c
+++ b/src/main.c
@@ -331,7 +331,19 @@ do_read(int sockfd, struct rustls_client_session *client_session)
     return CRUSTLS_DEMO_ERROR;
   }
 
-  return copy_plaintext_to_stdout(client_session);
+  result = copy_plaintext_to_stdout(client_session);
+  if(result != CRUSTLS_DEMO_CLOSE_NOTIFY) {
+    return result;
+  }
+
+  /* If we got a close_notify, verify that the sender then
+   * closed the TCP connection. */
+  n = read(sockfd, buf, sizeof(buf));
+  if(n != 0) {
+    fprintf(stderr, "read returned %ld after receiving close_notify\n", n);
+    return CRUSTLS_DEMO_ERROR;
+  }
+  return CRUSTLS_DEMO_CLOSE_NOTIFY;
 }
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@ enum crustls_demo_result
   CRUSTLS_DEMO_ERROR,
   CRUSTLS_DEMO_AGAIN,
   CRUSTLS_DEMO_EOF,
+  CRUSTLS_DEMO_CLOSE_NOTIFY,
 };
 
 void
@@ -241,7 +242,9 @@ fail:
  * Note that EOF here indicates "no more bytes until
  * process_new_packets", not "stream is closed".
  *
- * Returns 0 for success, 1 for error.
+ * Returns CRUSTLS_DEMO_OK for success,
+ * CRUSTLS_DEMO_ERROR for error,
+ * CRUSTLS_DEMO_CLOSE_NOTIFY for "received close_notify"
  */
 int
 copy_plaintext_to_stdout(struct rustls_client_session *client_session)
@@ -254,23 +257,27 @@ copy_plaintext_to_stdout(struct rustls_client_session *client_session)
     bzero(buf, sizeof(buf));
     result = rustls_client_session_read(
       client_session, (uint8_t *)buf, sizeof(buf), &n);
+    if(result == RUSTLS_RESULT_ALERT_CLOSE_NOTIFY) {
+      fprintf(stderr, "Received close_notify, cleanly ending connection\n");
+      return CRUSTLS_DEMO_CLOSE_NOTIFY;
+    }
     if(result != RUSTLS_RESULT_OK) {
       fprintf(stderr, "Error in ClientSession::read\n");
-      return 1;
+      return CRUSTLS_DEMO_ERROR;
     }
     if(n == 0) {
       /* EOF from ClientSession::read. This is expected. */
-      return 0;
+      return CRUSTLS_DEMO_OK;
     }
 
     result = write_all(STDOUT_FILENO, buf, n);
     if(result != 0) {
-      return result;
+      return CRUSTLS_DEMO_ERROR;
     }
   }
 
   fprintf(stderr, "copy_plaintext_to_stdout: fell through loop\n");
-  return 1;
+  return CRUSTLS_DEMO_ERROR;
 }
 
 /*
@@ -324,12 +331,7 @@ do_read(int sockfd, struct rustls_client_session *client_session)
     return CRUSTLS_DEMO_ERROR;
   }
 
-  result = copy_plaintext_to_stdout(client_session);
-  if(result != 0) {
-    return CRUSTLS_DEMO_ERROR;
-  }
-
-  return CRUSTLS_DEMO_OK;
+  return copy_plaintext_to_stdout(client_session);
 }
 
 /*
@@ -396,7 +398,7 @@ send_request_and_read_response(int sockfd,
         if(result == CRUSTLS_DEMO_AGAIN) {
           break;
         }
-        else if(result == CRUSTLS_DEMO_EOF) {
+        else if(result == CRUSTLS_DEMO_CLOSE_NOTIFY) {
           ret = 0;
           goto cleanup;
         }


### PR DESCRIPTION
In rustls, close_notify is expressed as an `io::Error` rather than a `TLSError`, presumably to be compatible with the `Read` trait:

https://github.com/ctz/rustls/blob/75d08697ab8ddbe3c0051dee195674b187c1717c/rustls/src/session.rs#L623-L628

https://github.com/ctz/rustls/blob/75d08697ab8ddbe3c0051dee195674b187c1717c/rustls/src/session.rs#L845-L850

In the C wrapper, we don't have to follow the `Read` trait, and can return the appropriate corresponding rustls_result. The functions no longer set `*out_n = 0` because of our "no partial failures" convention.

Update crustls-demo apropriately.

https://tools.ietf.org/html/rfc8446#section-6.1