### PR TITLE
Use a trait to constrain pointer casting

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -50,7 +50,7 @@ pub extern "C" fn rustls_certified_key_build(
     certified_key_out: *mut *const rustls_certified_key,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let certified_key_out: &mut *const rustls_certified_key= unsafe {
+        let certified_key_out: &mut *const rustls_certified_key = unsafe {
             match certified_key_out.as_mut() {
                 Some(c) => c,
                 None => return NullParameter,

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -23,7 +23,7 @@ pub struct rustls_certified_key {
 }
 
 impl CastPtr for rustls_certified_key {
-    type RustTy = CertifiedKey;
+    type RustType = CertifiedKey;
 }
 
 /// Build a `rustls_certified_key` from a certificate chain and a private key.

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -8,9 +8,7 @@ use rustls::{Certificate, PrivateKey};
 use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 
 use crate::error::rustls_result;
-use crate::{
-    ffi_panic_boundary, ffi_panic_boundary_generic, ffi_panic_boundary_unit, try_ref_from_ptr,
-};
+use crate::{ffi_panic_boundary, ffi_panic_boundary_generic, ffi_panic_boundary_unit, CastPtr};
 use rustls_result::NullParameter;
 
 /// The complete chain of certificates to send during a TLS handshake,
@@ -22,6 +20,10 @@ pub struct rustls_certified_key {
     // telling them what's inside.
     // https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
     _private: [u8; 0],
+}
+
+impl CastPtr for rustls_certified_key {
+    type RustTy = CertifiedKey;
 }
 
 /// Build a `rustls_certified_key` from a certificate chain and a private key.
@@ -48,8 +50,12 @@ pub extern "C" fn rustls_certified_key_build(
     certified_key_out: *mut *const rustls_certified_key,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let certified_key_out: &mut *const rustls_certified_key =
-            try_ref_from_ptr!(certified_key_out, &mut *const rustls_certified_key);
+        let certified_key_out: &mut *const rustls_certified_key= unsafe {
+            match certified_key_out.as_mut() {
+                Some(c) => c,
+                None => return NullParameter,
+            }
+        };
         let certified_key = match certified_key_build(
             cert_chain, cert_chain_len, private_key, private_key_len) {
             Ok(key) => Box::new(key),
@@ -68,9 +74,11 @@ pub extern "C" fn rustls_certified_key_build(
 /// consider this pointer unusable after "free"ing it.
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
-pub extern "C" fn rustls_certified_key_free(config: *const rustls_certified_key) {
+pub extern "C" fn rustls_certified_key_free(key: *const rustls_certified_key) {
     ffi_panic_boundary_unit! {
-        let key: &CertifiedKey = try_ref_from_ptr!(config, &mut CertifiedKey, ());
+        if key.is_null() {
+            return;
+        }
         // To free the certified_key, we reconstruct the Arc. It should have a refcount of 1,
         // representing the C code's copy. When it drops, that refcount will go down to 0
         // and the inner ServerConfig will be dropped.

--- a/src/client.rs
+++ b/src/client.rs
@@ -40,7 +40,7 @@ pub struct rustls_client_config_builder {
 }
 
 impl CastPtr for rustls_client_config_builder {
-    type RustTy = ClientConfig;
+    type RustType = ClientConfig;
 }
 
 /// A client config that is done being constructed and is now read-only.
@@ -54,7 +54,7 @@ pub struct rustls_client_config {
 }
 
 impl CastPtr for rustls_client_config {
-    type RustTy = ClientConfig;
+    type RustType = ClientConfig;
 }
 
 pub struct rustls_client_session {
@@ -62,7 +62,7 @@ pub struct rustls_client_session {
 }
 
 impl CastPtr for rustls_client_session {
-    type RustTy = ClientSession;
+    type RustType = ClientSession;
 }
 
 /// Create a rustls_client_config_builder. Caller owns the memory and must

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,7 +21,7 @@ use crate::session::{
 use crate::{
     arc_with_incref_from_raw, ffi_panic_boundary, ffi_panic_boundary_bool,
     ffi_panic_boundary_generic, ffi_panic_boundary_ptr, ffi_panic_boundary_unit, is_close_notify,
-    rslice::NulByte, try_ref_from_ptr,
+    rslice::NulByte, try_mut_from_ptr, try_ref_from_ptr, CastPtr,
 };
 use rustls_result::NullParameter;
 
@@ -39,6 +39,10 @@ pub struct rustls_client_config_builder {
     _private: [u8; 0],
 }
 
+impl CastPtr for rustls_client_config_builder {
+    type RustTy = ClientConfig;
+}
+
 /// A client config that is done being constructed and is now read-only.
 /// Under the hood, this object corresponds to an Arc<ClientConfig>.
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ClientConfig.html
@@ -49,8 +53,16 @@ pub struct rustls_client_config {
     _private: [u8; 0],
 }
 
+impl CastPtr for rustls_client_config {
+    type RustTy = ClientConfig;
+}
+
 pub struct rustls_client_session {
     _private: [u8; 0],
+}
+
+impl CastPtr for rustls_client_session {
+    type RustTy = ClientSession;
 }
 
 /// Create a rustls_client_config_builder. Caller owns the memory and must
@@ -74,8 +86,7 @@ pub extern "C" fn rustls_client_config_builder_build(
     builder: *mut rustls_client_config_builder,
 ) -> *const rustls_client_config {
     ffi_panic_boundary_ptr! {
-        let config: &mut ClientConfig = try_ref_from_ptr!(builder, &mut ClientConfig,
-             null::<rustls_client_config>());
+        let config: &mut ClientConfig = try_mut_from_ptr!(builder, null::<rustls_client_config>());
         let b = unsafe { Box::from_raw(config) };
         Arc::into_raw(Arc::new(*b)) as *const _
     }
@@ -231,7 +242,7 @@ pub extern "C" fn rustls_client_config_builder_dangerous_set_certificate_verifie
             Some(cb) => cb,
             None => return,
         };
-        let config: &mut ClientConfig = try_ref_from_ptr!(config, &mut ClientConfig, ());
+        let config: &mut ClientConfig = try_mut_from_ptr!(config,  ());
         let verifier: Verifier = Verifier{callback: callback, userdata};
         config.dangerous().set_certificate_verifier(Arc::new(verifier));
     }
@@ -244,7 +255,7 @@ pub extern "C" fn rustls_client_config_builder_load_native_roots(
     config: *mut rustls_client_config_builder,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let mut config: &mut ClientConfig = try_ref_from_ptr!(config, &mut ClientConfig);
+        let mut config: &mut ClientConfig = try_mut_from_ptr!(config);
         let store = match rustls_native_certs::load_native_certs() {
             Ok(store) => store,
             Err(_) => return rustls_result::Io,
@@ -268,7 +279,7 @@ pub extern "C" fn rustls_client_config_builder_load_roots_from_file(
             }
             CStr::from_ptr(filename)
         };
-        let config: &mut ClientConfig = try_ref_from_ptr!(config, &mut ClientConfig);
+        let config: &mut ClientConfig = try_mut_from_ptr!(config);
         let filename: &[u8] = filename.to_bytes();
         let filename: &str = match std::str::from_utf8(filename) {
             Ok(s) => s,
@@ -296,7 +307,7 @@ pub extern "C" fn rustls_client_config_builder_set_enable_sni(
     enable: bool,
 ) {
     ffi_panic_boundary_unit! {
-        let config: &mut ClientConfig = try_ref_from_ptr!(config, &mut ClientConfig, ());
+        let config: &mut ClientConfig = try_mut_from_ptr!(config, ());
         config.enable_sni = enable;
     }
 }
@@ -310,7 +321,7 @@ pub extern "C" fn rustls_client_config_builder_set_enable_sni(
 #[no_mangle]
 pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config) {
     ffi_panic_boundary_unit! {
-        let config: &ClientConfig = try_ref_from_ptr!(config, &ClientConfig, ());
+        let config: &ClientConfig = try_ref_from_ptr!(config,  ());
         // To free the client_config, we reconstruct the Arc and then drop it. It should
         // have a refcount of 1, representing the C code's copy. When it drops, that
         // refcount will go down to 0 and the inner ClientConfig will be dropped.
@@ -367,7 +378,7 @@ pub extern "C" fn rustls_client_session_new(
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_read(session: *const rustls_client_session) -> bool {
     ffi_panic_boundary_bool! {
-        let session: &ClientSession = try_ref_from_ptr!(session, &ClientSession, false);
+        let session: &ClientSession = try_ref_from_ptr!(session, false);
         session.wants_read()
     }
 }
@@ -375,7 +386,7 @@ pub extern "C" fn rustls_client_session_wants_read(session: *const rustls_client
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_write(session: *const rustls_client_session) -> bool {
     ffi_panic_boundary_bool! {
-        let session: &ClientSession = try_ref_from_ptr!(session, &ClientSession, false);
+        let session: &ClientSession = try_ref_from_ptr!(session,  false);
         session.wants_write()
     }
 }
@@ -385,7 +396,7 @@ pub extern "C" fn rustls_client_session_is_handshaking(
     session: *const rustls_client_session,
 ) -> bool {
     ffi_panic_boundary_bool! {
-        let session: &ClientSession = try_ref_from_ptr!(session, &ClientSession, false);
+        let session: &ClientSession = try_ref_from_ptr!(session,  false);
         session.is_handshaking()
     }
 }
@@ -395,7 +406,7 @@ pub extern "C" fn rustls_client_session_process_new_packets(
     session: *mut rustls_client_session,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession);
+        let session: &mut ClientSession = try_mut_from_ptr!(session);
         match session.process_new_packets() {
             Ok(()) => rustls_result::Ok,
             Err(e) => return map_error(e),
@@ -408,7 +419,7 @@ pub extern "C" fn rustls_client_session_process_new_packets(
 #[no_mangle]
 pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_client_session) {
     ffi_panic_boundary_unit! {
-        let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession, ());
+        let session: &mut ClientSession = try_mut_from_ptr!(session,  ());
         session.send_close_notify()
     }
 }
@@ -418,7 +429,7 @@ pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_c
 #[no_mangle]
 pub extern "C" fn rustls_client_session_free(session: *mut rustls_client_session) {
     ffi_panic_boundary_unit! {
-        let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession, ());
+        let session: &mut ClientSession = try_mut_from_ptr!(session,  ());
         // Convert the pointer to a Box and drop it.
         unsafe { Box::from_raw(session); }
     }
@@ -438,7 +449,7 @@ pub extern "C" fn rustls_client_session_write(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession);
+        let session: &mut ClientSession = try_mut_from_ptr!(session);
         let write_buf: &[u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
@@ -481,14 +492,14 @@ pub extern "C" fn rustls_client_session_read(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession);
+        let session: &mut ClientSession = try_mut_from_ptr!(session);
         let read_buf: &mut [u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
+        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
         let n_read: usize = match session.read(read_buf) {
             Ok(n) => n,
             // Rustls turns close_notify alerts into `io::Error` of kind `ConnectionAborted`.
@@ -519,14 +530,14 @@ pub extern "C" fn rustls_client_session_read_tls(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession);
+        let session: &mut ClientSession = try_mut_from_ptr!(session);
         let input_buf: &[u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts(buf, count as usize)
         };
-        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
+        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
         let mut cursor = Cursor::new(input_buf);
         let n_read: usize = match session.read_tls(&mut cursor) {
             Ok(n) => n,
@@ -555,14 +566,14 @@ pub extern "C" fn rustls_client_session_write_tls(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession);
+        let session: &mut ClientSession = try_mut_from_ptr!(session);
         let mut output_buf: &mut [u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
+        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
         let n_written: usize = match session.write_tls(&mut output_buf) {
             Ok(n) => n,
             Err(_) => return rustls_result::Io,
@@ -596,7 +607,7 @@ pub extern "C" fn rustls_client_config_builder_set_persistence(
             Some(cb) => cb,
             None => return rustls_result::NullParameter,
         };
-        let config: &mut ClientConfig = try_ref_from_ptr!(builder, &mut ClientConfig);
+        let config: &mut ClientConfig = try_mut_from_ptr!(builder);
         config.set_persistence(Arc::new(SessionStoreBroker::new(
             userdata, get_cb, put_cb
         )));

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -405,7 +405,7 @@ enum rustls_result rustls_certified_key_build(const uint8_t *cert_chain,
  * consider this pointer unusable after "free"ing it.
  * Calling with NULL is fine. Must not be called twice with the same value.
  */
-void rustls_certified_key_free(const struct rustls_certified_key *config);
+void rustls_certified_key_free(const struct rustls_certified_key *key);
 
 /**
  * Create a rustls_client_config_builder. Caller owns the memory and must

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,48 @@ mod session;
 // Keep in sync with Cargo.toml.
 const RUSTLS_CRATE_VERSION: &str = "0.19.0";
 
+/// CastPtr represents the relationship between a snake case type (like rustls_client_session)
+/// and the corresponding Rust type (like ClientSession). For each matched pair of types, there
+/// should be an `impl CastPtr for snake_case { RustTy = SnakeCase }`.
+///
+/// This allows us to avoid using `as` in most places, and ensure that when we cast, we're
+/// preserving const-ness, and casting between the correct types.
+/// Implementing this is required in order to use `try_ref_from_ptr!`.
+pub(crate) trait CastPtr {
+    type RustTy;
+
+    fn cast_const_ptr(ptr: *const Self) -> *const Self::RustTy {
+        ptr as *const _
+    }
+
+    fn cast_mut_ptr(ptr: *mut Self) -> *mut Self::RustTy {
+        ptr as *mut _
+    }
+}
+
+/// Turn a raw const pointer into a reference. This is a generic function
+/// rather than part of the CastPtr trait because (a) const pointers can't act
+/// as "self" for trait methods, and (b) we want to rely on type inference
+/// against T (the cast-to type) rather than across F (the from type).
+pub(crate) fn try_from<F, T>(from: *const F) -> Option<&'static T>
+where
+    F: CastPtr<RustTy = T>,
+{
+    unsafe { F::cast_const_ptr(from).as_ref() }
+}
+
+/// Turn a raw mut pointer into a mutable reference.
+pub(crate) fn try_from_mut<F, T>(from: *mut F) -> Option<&'static mut T>
+where
+    F: CastPtr<RustTy = T>,
+{
+    unsafe { F::cast_mut_ptr(from).as_mut() }
+}
+
+impl CastPtr for size_t {
+    type RustTy = size_t;
+}
+
 #[macro_export]
 macro_rules! ffi_panic_boundary_generic {
     ( $retval:expr, $($tt:tt)* ) => {
@@ -87,27 +129,27 @@ macro_rules! ffi_panic_boundary_unit {
 ///
 #[macro_export]
 macro_rules! try_ref_from_ptr {
-    ( $var:ident, & $typ:ty ) => {
-        try_ref_from_ptr!($var, &$typ, rustls_result::NullParameter)
+    ( $var:ident ) => {
+        try_ref_from_ptr!($var, rustls_result::NullParameter)
     };
-    ( $var:ident, & $typ:ty, $retval: expr ) => {
-        unsafe {
-            match ($var as *const $typ).as_ref() {
-                Some(c) => c,
-                None => return $retval,
-            }
-        };
+    ( $var:ident, $retval:expr ) => {
+        match crate::try_from($var) {
+            Some(c) => c,
+            None => return $retval,
+        }
     };
-    ( $var:ident, &mut $typ:ty ) => {
-        try_ref_from_ptr!($var, &mut $typ, rustls_result::NullParameter)
+}
+
+#[macro_export]
+macro_rules! try_mut_from_ptr {
+    ( $var:ident ) => {
+        try_mut_from_ptr!($var, rustls_result::NullParameter)
     };
-    ( $var:ident, &mut $typ:ty, $retval:expr ) => {
-        unsafe {
-            match ($var as *mut $typ).as_mut() {
-                Some(c) => c,
-                None => return $retval,
-            }
-        };
+    ( $var:ident, $retval:expr ) => {
+        match crate::try_from_mut($var) {
+            Some(c) => c,
+            None => return $retval,
+        }
     };
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,7 @@ pub struct rustls_server_config_builder {
 }
 
 impl CastPtr for rustls_server_config_builder {
-    type RustTy = ServerConfig;
+    type RustType = ServerConfig;
 }
 
 /// A server config that is done being constructed and is now read-only.
@@ -56,7 +56,7 @@ pub struct rustls_server_config {
 }
 
 impl CastPtr for rustls_server_config {
-    type RustTy = ServerConfig;
+    type RustType = ServerConfig;
 }
 
 pub struct rustls_server_session {
@@ -64,7 +64,7 @@ pub struct rustls_server_session {
 }
 
 impl CastPtr for rustls_server_session {
-    type RustTy = ServerSession;
+    type RustType = ServerSession;
 }
 
 /// Create a rustls_server_config_builder. Caller owns the memory and must

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,10 +7,12 @@ use std::ptr::null_mut;
 use std::slice;
 use std::sync::Arc;
 
-use rustls::{sign::CertifiedKey, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use rustls::ResolvesServerCert;
 use rustls::{ClientHello, NoClientAuth, ServerConfig, ServerSession, Session};
 use rustls_result::NullParameter;
 
+use crate::cipher::rustls_certified_key;
 use crate::enums::rustls_tls_version_from_u16;
 use crate::error::{map_error, rustls_result};
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_slice_u16, rustls_str};
@@ -19,11 +21,10 @@ use crate::session::{
     rustls_session_store_userdata, SessionStoreBroker, SessionStoreGetCallback,
     SessionStorePutCallback,
 };
-use crate::{arc_with_incref_from_raw, cipher::rustls_certified_key};
 use crate::{
-    ffi_panic_boundary, ffi_panic_boundary_bool, ffi_panic_boundary_generic,
-    ffi_panic_boundary_ptr, ffi_panic_boundary_u16, ffi_panic_boundary_unit, is_close_notify,
-    try_ref_from_ptr,
+    arc_with_incref_from_raw, ffi_panic_boundary, ffi_panic_boundary_bool,
+    ffi_panic_boundary_generic, ffi_panic_boundary_ptr, ffi_panic_boundary_u16,
+    ffi_panic_boundary_unit, is_close_notify, try_mut_from_ptr, try_ref_from_ptr, CastPtr,
 };
 
 /// A server config being constructed. A builder can be modified by,
@@ -40,6 +41,10 @@ pub struct rustls_server_config_builder {
     _private: [u8; 0],
 }
 
+impl CastPtr for rustls_server_config_builder {
+    type RustTy = ServerConfig;
+}
+
 /// A server config that is done being constructed and is now read-only.
 /// Under the hood, this object corresponds to an Arc<ServerConfig>.
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html
@@ -50,8 +55,16 @@ pub struct rustls_server_config {
     _private: [u8; 0],
 }
 
+impl CastPtr for rustls_server_config {
+    type RustTy = ServerConfig;
+}
+
 pub struct rustls_server_session {
     _private: [u8; 0],
+}
+
+impl CastPtr for rustls_server_session {
+    type RustTy = ServerSession;
 }
 
 /// Create a rustls_server_config_builder. Caller owns the memory and must
@@ -77,7 +90,7 @@ pub extern "C" fn rustls_server_config_builder_new() -> *mut rustls_server_confi
 #[no_mangle]
 pub extern "C" fn rustls_server_config_builder_free(config: *mut rustls_server_config_builder) {
     ffi_panic_boundary_unit! {
-        let config: &mut ServerConfig = try_ref_from_ptr!(config, &mut ServerConfig, ());
+        let config: &mut ServerConfig = try_mut_from_ptr!(config, ());
         // Convert the pointer to a Box and drop it.
         unsafe { Box::from_raw(config); }
     }
@@ -91,7 +104,7 @@ pub extern "C" fn rustls_server_config_builder_from_config(
     config: *const rustls_server_config,
 ) -> *mut rustls_server_config_builder {
     ffi_panic_boundary_ptr! {
-        let config: &ServerConfig = try_ref_from_ptr!(config, &ServerConfig, null_mut());
+        let config: &ServerConfig = try_ref_from_ptr!(config,  null_mut());
         Box::into_raw(Box::new(config.clone())) as *mut _
     }
 }
@@ -111,7 +124,7 @@ pub extern "C" fn rustls_server_config_builder_set_versions(
     len: size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig);
+        let config: &mut ServerConfig = try_mut_from_ptr!(builder);
         config.versions.clear();
         unsafe {
             // rustls does not support an `Unkown(u16)` protocol version,
@@ -135,7 +148,7 @@ pub extern "C" fn rustls_server_config_builder_set_ignore_client_order(
     ignore: bool,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig);
+        let config: &mut ServerConfig = try_mut_from_ptr!(builder);
         config.ignore_client_order = ignore;
         rustls_result::Ok
     }
@@ -158,7 +171,7 @@ pub extern "C" fn rustls_server_config_builder_set_protocols(
     len: size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig);
+        let config: &mut ServerConfig = try_mut_from_ptr!(builder);
         let protocols: &[rustls_slice_bytes] = unsafe {
             if protocols.is_null() {
                 return NullParameter;
@@ -201,7 +214,7 @@ pub extern "C" fn rustls_server_config_builder_set_certified_keys(
     certified_keys_len: size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig);
+        let config: &mut ServerConfig = try_mut_from_ptr!(builder);
         let keys_ptrs: &[*const rustls_certified_key] = unsafe {
             if certified_keys.is_null() {
                 return NullParameter;
@@ -210,8 +223,7 @@ pub extern "C" fn rustls_server_config_builder_set_certified_keys(
         };
         let mut keys: Vec<Arc<CertifiedKey>> = Vec::new();
         for &key_ptr in keys_ptrs {
-            let key_ptr: &CertifiedKey = try_ref_from_ptr!(key_ptr,
-                &CertifiedKey);
+            let key_ptr: &CertifiedKey = try_ref_from_ptr!(key_ptr);
             let certified_key: Arc<CertifiedKey> = unsafe {
                 match (key_ptr as *const CertifiedKey).as_ref() {
                     Some(c) => arc_with_incref_from_raw(c),
@@ -232,8 +244,7 @@ pub extern "C" fn rustls_server_config_builder_build(
     builder: *mut rustls_server_config_builder,
 ) -> *const rustls_server_config {
     ffi_panic_boundary_ptr! {
-        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig,
-             null::<rustls_server_config>());
+        let config: &mut ServerConfig = try_mut_from_ptr!(builder, null());
         let b = unsafe { Box::from_raw(config) };
         Arc::into_raw(Arc::new(*b)) as *const _
     }
@@ -248,7 +259,7 @@ pub extern "C" fn rustls_server_config_builder_build(
 #[no_mangle]
 pub extern "C" fn rustls_server_config_free(config: *const rustls_server_config) {
     ffi_panic_boundary_unit! {
-        let config: &ServerConfig = try_ref_from_ptr!(config, &mut ServerConfig, ());
+        let config: &ServerConfig = try_ref_from_ptr!(config, ());
         // To free the server_config, we reconstruct the Arc. It should have a refcount of 1,
         // representing the C code's copy. When it drops, that refcount will go down to 0
         // and the inner ServerConfig will be dropped.
@@ -290,7 +301,7 @@ pub extern "C" fn rustls_server_session_new(
 #[no_mangle]
 pub extern "C" fn rustls_server_session_wants_read(session: *const rustls_server_session) -> bool {
     ffi_panic_boundary_bool! {
-        let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, false);
+        let session: &ServerSession = try_ref_from_ptr!(session, false);
         session.wants_read()
     }
 }
@@ -298,7 +309,7 @@ pub extern "C" fn rustls_server_session_wants_read(session: *const rustls_server
 #[no_mangle]
 pub extern "C" fn rustls_server_session_wants_write(session: *const rustls_server_session) -> bool {
     ffi_panic_boundary_bool! {
-        let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, false);
+        let session: &ServerSession = try_ref_from_ptr!(session, false);
         session.wants_write()
     }
 }
@@ -308,7 +319,7 @@ pub extern "C" fn rustls_server_session_is_handshaking(
     session: *const rustls_server_session,
 ) -> bool {
     ffi_panic_boundary_bool! {
-        let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, false);
+        let session: &ServerSession = try_ref_from_ptr!(session, false);
         session.is_handshaking()
     }
 }
@@ -321,7 +332,7 @@ pub extern "C" fn rustls_server_session_get_protocol_version(
     session: *const rustls_server_session,
 ) -> u16 {
     ffi_panic_boundary_u16! {
-        let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, 0);
+        let session: &ServerSession = try_ref_from_ptr!(session, 0);
         match session.get_protocol_version() {
             Some(v) => v.get_u16(),
             None => 0
@@ -334,7 +345,7 @@ pub extern "C" fn rustls_server_session_process_new_packets(
     session: *mut rustls_server_session,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession);
+        let session: &mut ServerSession = try_mut_from_ptr!(session);
         match session.process_new_packets() {
             Ok(()) => rustls_result::Ok,
             Err(e) => return map_error(e),
@@ -347,7 +358,7 @@ pub extern "C" fn rustls_server_session_process_new_packets(
 #[no_mangle]
 pub extern "C" fn rustls_server_session_send_close_notify(session: *mut rustls_server_session) {
     ffi_panic_boundary_unit! {
-        let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession, ());
+        let session: &mut ServerSession = try_mut_from_ptr!(session, ());
         session.send_close_notify()
     }
 }
@@ -357,7 +368,7 @@ pub extern "C" fn rustls_server_session_send_close_notify(session: *mut rustls_s
 #[no_mangle]
 pub extern "C" fn rustls_server_session_free(session: *mut rustls_server_session) {
     ffi_panic_boundary_unit! {
-        let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession, ());
+        let session: &mut ServerSession = try_mut_from_ptr!(session, ());
         // Convert the pointer to a Box and drop it.
         unsafe { Box::from_raw(session); }
     }
@@ -377,7 +388,7 @@ pub extern "C" fn rustls_server_session_write(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession);
+        let session: &mut ServerSession = try_mut_from_ptr!(session);
         let write_buf: &[u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
@@ -420,14 +431,14 @@ pub extern "C" fn rustls_server_session_read(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession);
+        let session: &mut ServerSession = try_mut_from_ptr!(session);
         let read_buf: &mut [u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
+        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
         let n_read: usize = match session.read(read_buf) {
             Ok(n) => n,
             // Rustls turns close_notify alerts into `io::Error` of kind `ConnectionAborted`.
@@ -458,14 +469,14 @@ pub extern "C" fn rustls_server_session_read_tls(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession);
+        let session: &mut ServerSession = try_mut_from_ptr!(session);
         let input_buf: &[u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts(buf, count as usize)
         };
-        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
+        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
         let mut cursor = Cursor::new(input_buf);
         let n_read: usize = match session.read_tls(&mut cursor) {
             Ok(n) => n,
@@ -494,14 +505,14 @@ pub extern "C" fn rustls_server_session_write_tls(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession);
+        let session: &mut ServerSession = try_mut_from_ptr!(session);
         let mut output_buf: &mut [u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts_mut(buf, count as usize)
         };
-        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
+        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
         let n_written: usize = match session.write_tls(&mut output_buf) {
             Ok(n) => n,
             Err(_) => return rustls_result::Io,
@@ -526,14 +537,14 @@ pub extern "C" fn rustls_server_session_get_sni_hostname(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, NullParameter);
+        let session: &ServerSession = try_ref_from_ptr!(session);
         let write_buf: &mut [u8] = unsafe {
             if buf.is_null() {
                 return NullParameter;
             }
             slice::from_raw_parts_mut(buf as *mut u8, count as usize)
         };
-        let out_n: &mut size_t = try_ref_from_ptr!(out_n, &mut size_t);
+        let out_n: &mut size_t = try_mut_from_ptr!(out_n);
         let sni_hostname = match session.get_sni_hostname() {
             Some(sni_hostname) => sni_hostname,
             None => {
@@ -677,7 +688,7 @@ impl ResolvesServerCert for ClientHelloResolver {
         };
         let cb = self.callback;
         let key_ptr: *const rustls_certified_key = unsafe { cb(self.userdata, &hello) };
-        let certified_key: &CertifiedKey = try_ref_from_ptr!(key_ptr, &CertifiedKey, None);
+        let certified_key: &CertifiedKey = try_ref_from_ptr!(key_ptr, None);
         Some(certified_key.clone())
     }
 }
@@ -712,7 +723,7 @@ pub extern "C" fn rustls_server_config_builder_set_hello_callback(
             Some(cb) => cb,
             None => return rustls_result::NullParameter,
         };
-        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig);
+        let config: &mut ServerConfig = try_mut_from_ptr!(builder);
         config.cert_resolver = Arc::new(ClientHelloResolver::new(
             callback, userdata
         ));
@@ -742,7 +753,7 @@ pub extern "C" fn rustls_server_config_builder_set_persistence(
             Some(cb) => cb,
             None => return rustls_result::NullParameter,
         };
-        let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig);
+        let config: &mut ServerConfig = try_mut_from_ptr!(builder);
         config.set_persistence(Arc::new(SessionStoreBroker::new(
             userdata, get_cb, put_cb
         )));


### PR DESCRIPTION
This removes a category of bugs where we cast away constness or cast
between types. It also allows us to rely on type inference in
`try_ref_from_ptr!`, which lets us remove the type parameter to that
macro, simplifying invocations.

This requires splitting out a separate `try_mut_from_ptr!` for mutable
casts.