### PR TITLE
Allow EWOULDBLOCK after close_notify.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -339,8 +339,8 @@ do_read(int sockfd, struct rustls_client_session *client_session)
   /* If we got a close_notify, verify that the sender then
    * closed the TCP connection. */
   n = read(sockfd, buf, sizeof(buf));
-  if(n != 0) {
-    fprintf(stderr, "read returned %ld after receiving close_notify\n", n);
+  if(n != 0 && errno != EWOULDBLOCK) {
+    fprintf(stderr, "read returned %ld after receiving close_notify: %s\n", n, strerror(errno));
     return CRUSTLS_DEMO_ERROR;
   }
   return CRUSTLS_DEMO_CLOSE_NOTIFY;


### PR DESCRIPTION
In #67, we added a check that after close_notify, we receive an EOF
from the TCP connection (not additional bytes or an error). However,
sometimes we can get an EWOULDBLOCK. We should consider that OK and not
wait around to be totally sure we got the TCP close.

Alternately we could go back to polling mode to make sure we eventually
did get the TCP close, but this seems simpler.