### PR TITLE
Simplify ffi_panic_boundary

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -8,9 +8,7 @@ use rustls::{Certificate, PrivateKey};
 use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 
 use crate::error::rustls_result;
-use crate::{
-    ffi_panic_boundary, ffi_panic_boundary_generic, ffi_panic_boundary_unit, try_ref_from_ptr,
-};
+use crate::{ffi_panic_boundary, try_ref_from_ptr};
 use rustls_result::NullParameter;
 
 /// The complete chain of certificates to send during a TLS handshake,
@@ -69,7 +67,7 @@ pub extern "C" fn rustls_certified_key_build(
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
 pub extern "C" fn rustls_certified_key_free(config: *const rustls_certified_key) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let key: &CertifiedKey = try_ref_from_ptr!(config, &mut CertifiedKey, ());
         // To free the certified_key, we reconstruct the Arc. It should have a refcount of 1,
         // representing the C code's copy. When it drops, that refcount will go down to 0

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,9 +19,8 @@ use crate::session::{
     SessionStorePutCallback,
 };
 use crate::{
-    arc_with_incref_from_raw, ffi_panic_boundary, ffi_panic_boundary_bool,
-    ffi_panic_boundary_generic, ffi_panic_boundary_ptr, ffi_panic_boundary_unit, is_close_notify,
-    rslice::NulByte, try_ref_from_ptr,
+    arc_with_incref_from_raw, ffi_panic_boundary, is_close_notify, rslice::NulByte,
+    try_ref_from_ptr,
 };
 use rustls_result::NullParameter;
 
@@ -60,7 +59,7 @@ pub struct rustls_client_session {
 /// or rustls_client_config_builder_load_roots_from_file.
 #[no_mangle]
 pub extern "C" fn rustls_client_config_builder_new() -> *mut rustls_client_config_builder {
-    ffi_panic_boundary_ptr! {
+    ffi_panic_boundary! {
         let config = rustls::ClientConfig::new();
         let b = Box::new(config);
         Box::into_raw(b) as *mut _
@@ -73,7 +72,7 @@ pub extern "C" fn rustls_client_config_builder_new() -> *mut rustls_client_confi
 pub extern "C" fn rustls_client_config_builder_build(
     builder: *mut rustls_client_config_builder,
 ) -> *const rustls_client_config {
-    ffi_panic_boundary_ptr! {
+    ffi_panic_boundary! {
         let config: &mut ClientConfig = try_ref_from_ptr!(builder, &mut ClientConfig,
              null::<rustls_client_config>());
         let b = unsafe { Box::from_raw(config) };
@@ -226,7 +225,7 @@ pub extern "C" fn rustls_client_config_builder_dangerous_set_certificate_verifie
     callback: rustls_verify_server_cert_callback,
     userdata: rustls_verify_server_cert_user_data,
 ) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let callback: VerifyCallback = match callback {
             Some(cb) => cb,
             None => return,
@@ -295,7 +294,7 @@ pub extern "C" fn rustls_client_config_builder_set_enable_sni(
     config: *mut rustls_client_config_builder,
     enable: bool,
 ) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let config: &mut ClientConfig = try_ref_from_ptr!(config, &mut ClientConfig, ());
         config.enable_sni = enable;
     }
@@ -309,7 +308,7 @@ pub extern "C" fn rustls_client_config_builder_set_enable_sni(
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
 pub extern "C" fn rustls_client_config_free(config: *const rustls_client_config) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let config: &ClientConfig = try_ref_from_ptr!(config, &ClientConfig, ());
         // To free the client_config, we reconstruct the Arc and then drop it. It should
         // have a refcount of 1, representing the C code's copy. When it drops, that
@@ -366,7 +365,7 @@ pub extern "C" fn rustls_client_session_new(
 
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_read(session: *const rustls_client_session) -> bool {
-    ffi_panic_boundary_bool! {
+    ffi_panic_boundary! {
         let session: &ClientSession = try_ref_from_ptr!(session, &ClientSession, false);
         session.wants_read()
     }
@@ -374,7 +373,7 @@ pub extern "C" fn rustls_client_session_wants_read(session: *const rustls_client
 
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_write(session: *const rustls_client_session) -> bool {
-    ffi_panic_boundary_bool! {
+    ffi_panic_boundary! {
         let session: &ClientSession = try_ref_from_ptr!(session, &ClientSession, false);
         session.wants_write()
     }
@@ -384,7 +383,7 @@ pub extern "C" fn rustls_client_session_wants_write(session: *const rustls_clien
 pub extern "C" fn rustls_client_session_is_handshaking(
     session: *const rustls_client_session,
 ) -> bool {
-    ffi_panic_boundary_bool! {
+    ffi_panic_boundary! {
         let session: &ClientSession = try_ref_from_ptr!(session, &ClientSession, false);
         session.is_handshaking()
     }
@@ -407,7 +406,7 @@ pub extern "C" fn rustls_client_session_process_new_packets(
 /// https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.send_close_notify
 #[no_mangle]
 pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_client_session) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession, ());
         session.send_close_notify()
     }
@@ -417,7 +416,7 @@ pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_c
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
 pub extern "C" fn rustls_client_session_free(session: *mut rustls_client_session) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let session: &mut ClientSession = try_ref_from_ptr!(session, &mut ClientSession, ());
         // Convert the pointer to a Box and drop it.
         unsafe { Box::from_raw(session); }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::{cmp::min, fmt::Display, slice};
 
-use crate::{ffi_panic_boundary_generic, ffi_panic_boundary_unit};
+use crate::ffi_panic_boundary;
 use libc::{c_char, size_t};
 use rustls::TLSError;
 
@@ -15,7 +15,7 @@ pub extern "C" fn rustls_error(
     len: size_t,
     out_n: *mut size_t,
 ) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let write_buf: &mut [u8] = unsafe {
             let out_n: &mut size_t = match out_n.as_mut() {
                 Some(out_n) => out_n,

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -7,10 +7,6 @@ use std::ptr::{null, null_mut};
 // rustls_result, we return a dedicated error code: `Panic`. For functions
 // that don't return rustls_result, we return a default value: false, 0, or
 // null. This trait provides that logic.
-// Note: It's tempting to do a blanket `impl<T> PanicOrDefault for T: Default`.
-// However, that would conflict with the impls for `*mut T` and `*const T`.
-// Though those types currently don't implement Default, Rust disallows the
-// conflict because upstream might later implement it for them.
 pub(crate) trait PanicOrDefault {
     fn value() -> Self;
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -15,30 +15,19 @@ pub(crate) trait PanicOrDefault {
     fn value() -> Self;
 }
 
-impl PanicOrDefault for rustls_result {
-    fn value() -> Self {
-        rustls_result::Panic
-    }
-}
+// Defaultable is a subset of Default that can be returned by crustls.
+// We use this rather than Default directly so that we can do a blanket
+// impl for `T: Defaultable`. The compiler disallows a blanket impl for
+// `T: Default` because `std::default` could later implement `Default`
+// for `*mut T` and `*const T`.
+pub(crate) trait Defaultable: Default {}
 
-impl PanicOrDefault for u16 {
-    fn value() -> Self {
-        Default::default()
-    }
-}
+impl Defaultable for u16 {}
+impl Defaultable for usize {}
+impl Defaultable for bool {}
+impl Defaultable for () {}
 
-impl PanicOrDefault for usize {
-    fn value() -> Self {
-        Default::default()
-    }
-}
-impl PanicOrDefault for bool {
-    fn value() -> Self {
-        Default::default()
-    }
-}
-
-impl PanicOrDefault for () {
+impl<T: Defaultable> PanicOrDefault for T {
     fn value() -> Self {
         Default::default()
     }
@@ -53,6 +42,12 @@ impl<T> PanicOrDefault for *mut T {
 impl<T> PanicOrDefault for *const T {
     fn value() -> Self {
         null()
+    }
+}
+
+impl PanicOrDefault for rustls_result {
+    fn value() -> Self {
+        rustls_result::Panic
     }
 }
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,69 @@
+use crate::error::rustls_result;
+
+use std::ptr::{null, null_mut};
+
+// We wrap all function calls in an ffi_panic_boundary! macro, which catches
+// panics and early-returns from the function. For functions that return
+// rustls_result, we return a dedicated error code: `Panic`. For functions
+// that don't return rustls_result, we return a default value: false, 0, or
+// null. This trait provides that logic.
+// Note: It's tempting to do a blanket `impl<T> PanicOrDefault for T: Default`.
+// However, that would conflict with the impls for `*mut T` and `*const T`.
+// Though those types currently don't implement Default, Rust disallows the
+// conflict because upstream might later implement it for them.
+pub(crate) trait PanicOrDefault {
+    fn value() -> Self;
+}
+
+impl PanicOrDefault for rustls_result {
+    fn value() -> Self {
+        rustls_result::Panic
+    }
+}
+
+impl PanicOrDefault for u16 {
+    fn value() -> Self {
+        Default::default()
+    }
+}
+
+impl PanicOrDefault for usize {
+    fn value() -> Self {
+        Default::default()
+    }
+}
+impl PanicOrDefault for bool {
+    fn value() -> Self {
+        Default::default()
+    }
+}
+
+impl PanicOrDefault for () {
+    fn value() -> Self {
+        Default::default()
+    }
+}
+
+impl<T> PanicOrDefault for *mut T {
+    fn value() -> Self {
+        null_mut()
+    }
+}
+
+impl<T> PanicOrDefault for *const T {
+    fn value() -> Self {
+        null()
+    }
+}
+
+#[macro_export]
+macro_rules! ffi_panic_boundary {
+    ( $($tt:tt)* ) => {
+        match ::std::panic::catch_unwind(|| {
+            $($tt)*
+        }) {
+            Ok(ret) => ret,
+            Err(_) => return crate::PanicOrDefault::value(),
+        }
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,11 +20,7 @@ use crate::session::{
     SessionStorePutCallback,
 };
 use crate::{arc_with_incref_from_raw, cipher::rustls_certified_key};
-use crate::{
-    ffi_panic_boundary, ffi_panic_boundary_bool, ffi_panic_boundary_generic,
-    ffi_panic_boundary_ptr, ffi_panic_boundary_u16, ffi_panic_boundary_unit, is_close_notify,
-    try_ref_from_ptr,
-};
+use crate::{ffi_panic_boundary, is_close_notify, try_ref_from_ptr};
 
 /// A server config being constructed. A builder can be modified by,
 /// e.g. rustls_server_config_builder_load_native_roots. Once you're
@@ -62,7 +58,7 @@ pub struct rustls_server_session {
 /// https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html#method.new
 #[no_mangle]
 pub extern "C" fn rustls_server_config_builder_new() -> *mut rustls_server_config_builder {
-    ffi_panic_boundary_ptr! {
+    ffi_panic_boundary! {
         let config = rustls::ServerConfig::new(Arc::new(NoClientAuth));
         let b = Box::new(config);
         Box::into_raw(b) as *mut _
@@ -76,7 +72,7 @@ pub extern "C" fn rustls_server_config_builder_new() -> *mut rustls_server_confi
 /// was created.
 #[no_mangle]
 pub extern "C" fn rustls_server_config_builder_free(config: *mut rustls_server_config_builder) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let config: &mut ServerConfig = try_ref_from_ptr!(config, &mut ServerConfig, ());
         // Convert the pointer to a Box and drop it.
         unsafe { Box::from_raw(config); }
@@ -90,7 +86,7 @@ pub extern "C" fn rustls_server_config_builder_free(config: *mut rustls_server_c
 pub extern "C" fn rustls_server_config_builder_from_config(
     config: *const rustls_server_config,
 ) -> *mut rustls_server_config_builder {
-    ffi_panic_boundary_ptr! {
+    ffi_panic_boundary! {
         let config: &ServerConfig = try_ref_from_ptr!(config, &ServerConfig, null_mut());
         Box::into_raw(Box::new(config.clone())) as *mut _
     }
@@ -231,7 +227,7 @@ pub extern "C" fn rustls_server_config_builder_set_certified_keys(
 pub extern "C" fn rustls_server_config_builder_build(
     builder: *mut rustls_server_config_builder,
 ) -> *const rustls_server_config {
-    ffi_panic_boundary_ptr! {
+    ffi_panic_boundary! {
         let config: &mut ServerConfig = try_ref_from_ptr!(builder, &mut ServerConfig,
              null::<rustls_server_config>());
         let b = unsafe { Box::from_raw(config) };
@@ -247,7 +243,7 @@ pub extern "C" fn rustls_server_config_builder_build(
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
 pub extern "C" fn rustls_server_config_free(config: *const rustls_server_config) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let config: &ServerConfig = try_ref_from_ptr!(config, &mut ServerConfig, ());
         // To free the server_config, we reconstruct the Arc. It should have a refcount of 1,
         // representing the C code's copy. When it drops, that refcount will go down to 0
@@ -289,7 +285,7 @@ pub extern "C" fn rustls_server_session_new(
 
 #[no_mangle]
 pub extern "C" fn rustls_server_session_wants_read(session: *const rustls_server_session) -> bool {
-    ffi_panic_boundary_bool! {
+    ffi_panic_boundary! {
         let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, false);
         session.wants_read()
     }
@@ -297,7 +293,7 @@ pub extern "C" fn rustls_server_session_wants_read(session: *const rustls_server
 
 #[no_mangle]
 pub extern "C" fn rustls_server_session_wants_write(session: *const rustls_server_session) -> bool {
-    ffi_panic_boundary_bool! {
+    ffi_panic_boundary! {
         let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, false);
         session.wants_write()
     }
@@ -307,7 +303,7 @@ pub extern "C" fn rustls_server_session_wants_write(session: *const rustls_serve
 pub extern "C" fn rustls_server_session_is_handshaking(
     session: *const rustls_server_session,
 ) -> bool {
-    ffi_panic_boundary_bool! {
+    ffi_panic_boundary! {
         let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, false);
         session.is_handshaking()
     }
@@ -320,7 +316,7 @@ pub extern "C" fn rustls_server_session_is_handshaking(
 pub extern "C" fn rustls_server_session_get_protocol_version(
     session: *const rustls_server_session,
 ) -> u16 {
-    ffi_panic_boundary_u16! {
+    ffi_panic_boundary! {
         let session: &ServerSession = try_ref_from_ptr!(session, &ServerSession, 0);
         match session.get_protocol_version() {
             Some(v) => v.get_u16(),
@@ -346,7 +342,7 @@ pub extern "C" fn rustls_server_session_process_new_packets(
 /// https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.send_close_notify
 #[no_mangle]
 pub extern "C" fn rustls_server_session_send_close_notify(session: *mut rustls_server_session) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession, ());
         session.send_close_notify()
     }
@@ -356,7 +352,7 @@ pub extern "C" fn rustls_server_session_send_close_notify(session: *mut rustls_s
 /// Calling with NULL is fine. Must not be called twice with the same value.
 #[no_mangle]
 pub extern "C" fn rustls_server_session_free(session: *mut rustls_server_session) {
-    ffi_panic_boundary_unit! {
+    ffi_panic_boundary! {
         let session: &mut ServerSession = try_ref_from_ptr!(session, &mut ServerSession, ());
         // Convert the pointer to a Box and drop it.
         unsafe { Box::from_raw(session); }


### PR DESCRIPTION
Having a separate macro for each possible return type was clunky. Now,
we have a trait that can be implemented for each return type we care
about, and a single `ff_ipanic_boundary` macro that uses that trait to
return the appropriate type for any situation.

Move the panic-handling code into its own file.

By the way, I intend to apply the same treatment to simplify try_ref_from_ptr,
but I want to do it after #73 lands. One thing at a time.