### PR TITLE
Allow enumeration and config of ciphersuites.

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -1,14 +1,15 @@
 use libc::size_t;
 use std::io::Cursor;
+use std::ptr::null;
 use std::slice;
 use std::sync::Arc;
 
-use rustls::sign::CertifiedKey;
+use rustls::{sign::CertifiedKey, SupportedCipherSuite, ALL_CIPHERSUITES};
 use rustls::{Certificate, PrivateKey};
 use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 
 use crate::error::rustls_result;
-use crate::{ffi_panic_boundary, CastPtr};
+use crate::{ffi_panic_boundary, try_ref_from_ptr, CastPtr};
 use rustls_result::NullParameter;
 
 /// The complete chain of certificates to send during a TLS handshake,
@@ -24,6 +25,42 @@ pub struct rustls_certified_key {
 
 impl CastPtr for rustls_certified_key {
     type RustType = CertifiedKey;
+}
+
+/// A cipher suite supported by rustls.
+pub struct rustls_supported_ciphersuite {
+    _private: [u8; 0],
+}
+
+impl CastPtr for rustls_supported_ciphersuite {
+    type RustType = SupportedCipherSuite;
+}
+
+/// Return a 16-bit unsigned integer corresponding to this cipher suite's assignment from
+/// <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>.
+/// The bytes from the assignment are interpreted in network order.
+#[no_mangle]
+pub extern "C" fn rustls_supported_ciphersuite_get_suite(
+    supported_ciphersuite: *const rustls_supported_ciphersuite,
+) -> u16 {
+    let supported_ciphersuite = try_ref_from_ptr!(supported_ciphersuite);
+    supported_ciphersuite.suite.get_u16()
+}
+
+/// The number of cipher suites supported by rustls. You may call `rustls_all_ciphersuites_get()`
+/// with indexes lower than this number.
+#[allow(dead_code)]
+pub const RUSTLS_ALL_CIPHERSUITES_LEN: size_t = 9;
+
+/// Get a pointer to a member of rustls' list of supported cipher suites. This will return non-NULL
+/// for 0 <= i < RUSTLS_ALL_CIPHERSUITES_LEN. The returned pointer is valid for the lifetime of
+/// the program and may be used directly when building a ClientConfig or ServerConfig.
+#[no_mangle]
+pub extern "C" fn rustls_all_ciphersuites_get(i: size_t) -> *const rustls_supported_ciphersuite {
+    match ALL_CIPHERSUITES.get(i) {
+        Some(&cs) => cs as *const SupportedCipherSuite as *const _,
+        None => null(),
+    }
 }
 
 /// Build a `rustls_certified_key` from a certificate chain and a private key.
@@ -135,4 +172,14 @@ fn certified_key_build(
         parsed_chain,
         Arc::new(signing_key),
     ))
+}
+
+mod tests {
+    #[test]
+    fn rustls_all_ciphersuites_len() {
+        assert_eq!(
+            super::RUSTLS_ALL_CIPHERSUITES_LEN,
+            rustls::ALL_CIPHERSUITES.len()
+        );
+    }
 }

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -6,6 +6,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * The number of cipher suites supported by rustls. You may call `rustls_all_ciphersuites_get()`
+ * with indexes lower than this number.
+ */
+#define RUSTLS_ALL_CIPHERSUITES_LEN 9
+
 typedef enum rustls_result {
   RUSTLS_RESULT_OK = 7000,
   RUSTLS_RESULT_IO = 7001,
@@ -194,6 +200,11 @@ typedef struct rustls_slice_slice_bytes rustls_slice_slice_bytes;
 typedef struct rustls_slice_str rustls_slice_str;
 
 /**
+ * A cipher suite supported by rustls.
+ */
+typedef struct rustls_supported_ciphersuite rustls_supported_ciphersuite;
+
+/**
  * User-provided input to a custom certificate verifier callback. See
  * rustls_client_config_builder_dangerous_set_certificate_verifier().
  */
@@ -373,6 +384,20 @@ typedef const struct rustls_certified_key *(*rustls_client_hello_callback)(rustl
  * and NUL terminated. Returns the number of bytes written before the NUL.
  */
 size_t rustls_version(char *buf, size_t len);
+
+/**
+ * Return a 16-bit unsigned integer corresponding to this cipher suite's assignment from
+ * <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>.
+ * The bytes from the assignment are interpreted in network order.
+ */
+uint16_t rustls_supported_ciphersuite_get_suite(const struct rustls_supported_ciphersuite *supported_ciphersuite);
+
+/**
+ * Get a pointer to a member of rustls' list of supported cipher suites. This will return non-NULL
+ * for 0 <= i < RUSTLS_ALL_CIPHERSUITES_LEN. The returned pointer is valid for the lifetime of
+ * the program and may be used directly when building a ClientConfig or ServerConfig.
+ */
+const struct rustls_supported_ciphersuite *rustls_all_ciphersuites_get(size_t i);
 
 /**
  * Build a `rustls_certified_key` from a certificate chain and a private key.
@@ -703,6 +728,17 @@ enum rustls_result rustls_server_config_builder_set_protocols(struct rustls_serv
                                                               size_t len);
 
 /**
+ * Set the cipher suite list, in preference order. The `ciphersuites`
+ * parameter must point to an array containing `len` pointers to
+ * `rustls_supported_ciphersuite` previously obtained from
+ * `rustls_all_ciphersuites_get()`.
+ * https://docs.rs/rustls/0.19.0/rustls/struct.ServerConfig.html#structfield.ciphersuites
+ */
+enum rustls_result rustls_server_config_builder_set_ciphersuites(struct rustls_server_config_builder *builder,
+                                                                 const struct rustls_supported_ciphersuite *const *ciphersuites,
+                                                                 size_t len);
+
+/**
  * Provide the configuration a list of certificates where the session
  * will select the first one that is compatible with the client's signature
  * verification capabilities. Servers that want to support both ECDSA and
@@ -852,6 +888,13 @@ enum rustls_result rustls_server_session_get_sni_hostname(const struct rustls_se
                                                           uint8_t *buf,
                                                           size_t count,
                                                           size_t *out_n);
+
+/**
+ * Retrieves the cipher suite agreed with the peer.
+ * This returns NULL until the ciphersuite is agreed.
+ * https://docs.rs/rustls/0.19.0/rustls/trait.Session.html#tymethod.get_negotiated_ciphersuite
+ */
+const struct rustls_supported_ciphersuite *rustls_server_session_get_negotiated_ciphersuite(const struct rustls_server_session *session);
 
 /**
  * Register a callback to be invoked when a session created from this config


### PR DESCRIPTION
Define an opaque struct for SupportedCipherSuite, and an accessor for ALL_CIPHERSUITES. Add configuration for setting the list of cipher suites in ServerConfig, and for getting the negotiated cipher suite from a ServerSession.

@icing this is a counterproposal to #68. I wanted to try and avoid the complexity of the callback approach. ALL_CIPHERSUITES is a static, so we can rely on it living for the whole life of the program, which makes iterating over it somewhat easier. I haven't yet implemented parallel methods for ClientConfig and ClientSession because I wanted to get feedback first.