### PR TITLE
Prototype per-session userdata.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,9 +13,8 @@ use rustls::{
 use crate::error::{self, map_error, result_to_tlserror, rustls_result};
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_str};
 use crate::session::{
-    rustls_session_store_get_callback, rustls_session_store_put_callback,
-    rustls_session_store_userdata, SessionStoreBroker, SessionStoreGetCallback,
-    SessionStorePutCallback,
+    rustls_session_store_get_callback, rustls_session_store_put_callback, SessionStoreBroker,
+    SessionStoreGetCallback, SessionStorePutCallback,
 };
 use crate::{
     arc_with_incref_from_raw, ffi_panic_boundary, is_close_notify, rslice::NulByte,
@@ -575,7 +574,6 @@ pub extern "C" fn rustls_client_session_write_tls(
 #[no_mangle]
 pub extern "C" fn rustls_client_config_builder_set_persistence(
     builder: *mut rustls_client_config_builder,
-    userdata: rustls_session_store_userdata,
     get_cb: rustls_session_store_get_callback,
     put_cb: rustls_session_store_put_callback,
 ) -> rustls_result {
@@ -590,7 +588,7 @@ pub extern "C" fn rustls_client_config_builder_set_persistence(
         };
         let config: &mut ClientConfig = try_mut_from_ptr!(builder);
         config.set_persistence(Arc::new(SessionStoreBroker::new(
-            userdata, get_cb, put_cb
+            get_cb, put_cb
         )));
         rustls_result::Ok
     }

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -596,7 +596,6 @@ enum rustls_result rustls_client_session_write_tls(struct rustls_client_session 
  *
  */
 enum rustls_result rustls_client_config_builder_set_persistence(struct rustls_client_config_builder *builder,
-                                                                rustls_session_store_userdata userdata,
                                                                 rustls_session_store_get_callback get_cb,
                                                                 rustls_session_store_put_callback put_cb);
 
@@ -745,6 +744,7 @@ void rustls_server_config_free(const struct rustls_server_config *config);
  * `rustls_server_session_free` when done with it.
  */
 enum rustls_result rustls_server_session_new(const struct rustls_server_config *config,
+                                             void *userdata,
                                              struct rustls_server_session **session_out);
 
 bool rustls_server_session_wants_read(const struct rustls_server_session *session);
@@ -881,7 +881,6 @@ enum rustls_result rustls_server_config_builder_set_hello_callback(struct rustls
  * or other config created from that config object.
  */
 enum rustls_result rustls_server_config_builder_set_persistence(struct rustls_server_config_builder *builder,
-                                                                rustls_session_store_userdata userdata,
                                                                 rustls_session_store_get_callback get_cb,
                                                                 rustls_session_store_put_callback put_cb);
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -81,11 +81,11 @@ impl NullParameterOrDefault for rustls_result {
 #[macro_export]
 macro_rules! ffi_panic_boundary {
     ( $($tt:tt)* ) => {
-        match ::std::panic::catch_unwind(|| {
+        // match ::std::panic::catch_unwind(|| {
             $($tt)*
-        }) {
-            Ok(ret) => ret,
-            Err(_) => return crate::PanicOrDefault::value(),
-        }
+        // }) {
+        //     Ok(ret) => ret,
+        //     Err(_) => return crate::PanicOrDefault::value(),
+        // }
     }
 }


### PR DESCRIPTION
This introduces a `userdata: *mut c_void` parameter for
rustls_server_session_new, and changes `rustls_server_session` to be a
struct containing a Box<ServerSession> and a userdata pointer.

In rustls_server_session_process_new_packets, we set the thread-local
USERDATA to the session's value, call
ServerSession::process_new_packets(), then clear the thread-local.

This updates SessionStoreBroker to get its userdata parameter from the
session's userdata, rather than a config-wide userdata set at construction.

For this demo, disable catch_unwind because it introduces some issues
with UnwindSafe. We would have to resolve that before landing something
like this. Also, realistically we would want to take steps to ensure
userdata was reliably set and cleared before entry and exit from any
relevant rustls functions.

This compiles, but is completely untested so far. It's meant to give an
approximate shape of a solution for further discussion.

Related to #81.