### PR TITLE
Add OCSP Stapling provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
  - (empty)
 
+## 0.4.0 - 2021-04-29
+
+### Added
+
+ - ALPN support for clients (#84)
+ - Enumeration of ciphersuites (#79)
+
 ## 0.4.0 - 2021-03-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crustls"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["Jacob Hoffman-Andrews <github@hoffman-andrews.com>"]
 description = "C-to-rustls bindings"
 edition = "2018"

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -9,8 +9,10 @@ use rustls::{Certificate, PrivateKey};
 use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 
 use crate::error::rustls_result;
-use crate::{ffi_panic_boundary, try_ref_from_ptr, CastPtr};
+use crate::rslice::rustls_slice_bytes;
+use crate::{arc_with_incref_from_raw, ffi_panic_boundary, try_ref_from_ptr, try_slice, CastPtr};
 use rustls_result::NullParameter;
+use std::ops::Deref;
 
 /// The complete chain of certificates to send during a TLS handshake,
 /// plus a private key that matches the end-entity (leaf) certificate.
@@ -104,6 +106,43 @@ pub extern "C" fn rustls_certified_key_build(
         };
         let certified_key = Arc::into_raw(Arc::new(*certified_key)) as *const _;
         *certified_key_out = certified_key;
+        return rustls_result::Ok
+    }
+}
+
+/// Create a copy of the rustls_certified_key with the given OCSP response data
+/// as DER encoded bytes. The OCSP response may be given as NULL to clear any
+/// possibly present OCSP data from the cloned key.
+/// The cloned key is independent from its original and needs to be freed
+/// by the application.
+#[no_mangle]
+pub extern "C" fn rustls_certified_key_clone_with_ocsp(
+    key: *const rustls_certified_key,
+    ocsp_response: *const rustls_slice_bytes,
+    cloned_key_out: *mut *const rustls_certified_key,
+) -> rustls_result {
+    ffi_panic_boundary! {
+        let cloned_key_out: &mut *const rustls_certified_key = unsafe {
+            match cloned_key_out.as_mut() {
+                Some(c) => c,
+                None => return NullParameter,
+            }
+        };
+        let certified_key: Arc<CertifiedKey> = unsafe {
+            match (key as *const CertifiedKey).as_ref() {
+                Some(c) => arc_with_incref_from_raw(c),
+                None => return NullParameter,
+            }
+        };
+        let mut new_key = certified_key.deref().clone();
+        if !ocsp_response.is_null() {
+            let ocsp_slice = unsafe{ &*ocsp_response };
+            new_key.ocsp = Some(Vec::from(try_slice!(ocsp_slice.data, ocsp_slice.len)));
+        }
+        else {
+            new_key.ocsp = None;
+        }
+        *cloned_key_out = Arc::into_raw(Arc::new(new_key)) as *const _;
         return rustls_result::Ok
     }
 }

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -138,8 +138,7 @@ pub extern "C" fn rustls_certified_key_clone_with_ocsp(
         if !ocsp_response.is_null() {
             let ocsp_slice = unsafe{ &*ocsp_response };
             new_key.ocsp = Some(Vec::from(try_slice!(ocsp_slice.data, ocsp_slice.len)));
-        }
-        else {
+        } else {
             new_key.ocsp = None;
         }
         *cloned_key_out = Arc::into_raw(Arc::new(new_key)) as *const _;

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -199,12 +199,6 @@ typedef struct rustls_slice_str rustls_slice_str;
 typedef struct rustls_supported_ciphersuite rustls_supported_ciphersuite;
 
 /**
- * User-provided input to a custom certificate verifier callback. See
- * rustls_client_config_builder_dangerous_set_certificate_verifier().
- */
-typedef void *rustls_verify_server_cert_user_data;
-
-/**
  * A read-only view on a Rust byte slice.
  *
  * This is used to pass data from crustls to callback functions provided
@@ -221,6 +215,12 @@ typedef struct rustls_slice_bytes {
   const uint8_t *data;
   size_t len;
 } rustls_slice_bytes;
+
+/**
+ * User-provided input to a custom certificate verifier callback. See
+ * rustls_client_config_builder_dangerous_set_certificate_verifier().
+ */
+typedef void *rustls_verify_server_cert_user_data;
 
 /**
  * A read-only view on a Rust `&str`. The contents are guaranteed to be valid
@@ -421,6 +421,17 @@ enum rustls_result rustls_certified_key_build(const uint8_t *cert_chain,
                                               const uint8_t *private_key,
                                               size_t private_key_len,
                                               const struct rustls_certified_key **certified_key_out);
+
+/**
+ * Create a copy of the rustls_certified_key with the given OCSP response data
+ * as DER encoded bytes. The OCSP response may be given as NULL to clear any
+ * possibly present OCSP data from the cloned key.
+ * The cloned key is independent from its original and needs to be freed
+ * by the application.
+ */
+enum rustls_result rustls_certified_key_clone_with_ocsp(const struct rustls_certified_key *key,
+                                                        const struct rustls_slice_bytes *ocsp_response,
+                                                        const struct rustls_certified_key **cloned_key_out);
 
 /**
  * "Free" a certified_key previously returned from


### PR DESCRIPTION
Since OCSP response data is part of a rustls `CertifiedKey`, it needs to be added (when available) during the resolution of the server session certificate. This PR adds a callback to the API that can be installed (or given as NULL) when setting the list of CertifiedKeys on a SessionConfig.

Rationale: a callback is necessary, since OCSP response data has a max lifetime, commonly of a few days. Since server restarts are independent of this, the timeout of a known response might happen at any time. Also, when starting a server, no (valid) response might be readily available.

This makes OCSP response provisioning more dynamic than the rustls API seems to foresee. Hence a callback interface. The provided buffer makes sure that copying is cheap and buffer lifetimes are clear. Since a resolved certified key needs to be cloned anyway and the OCSP data is "taken" by the session, this should add little to no overhead.

