### PR TITLE
Make userdata a per-session config

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use libc::{c_char, c_void, size_t};
-use std::{convert::TryInto, ptr::null_mut};
 use std::io::{BufReader, Cursor, Read, Write};
 use std::slice;
+use std::{convert::TryInto, ptr::null_mut};
 use std::{ffi::CStr, sync::Arc};
 use std::{ffi::OsStr, fs::File};
 use webpki::DNSNameRef;
@@ -13,13 +13,13 @@ use rustls::{
 use crate::error::{self, map_error, result_to_tlserror, rustls_result};
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_str};
 use crate::session::{
-    rustls_session_store_get_callback, rustls_session_store_put_callback,
-    SessionStoreBroker, SessionStoreGetCallback, SessionStorePutCallback,
+    rustls_session_store_get_callback, rustls_session_store_put_callback, SessionStoreBroker,
+    SessionStoreGetCallback, SessionStorePutCallback,
 };
 use crate::{
     arc_with_incref_from_raw, ffi_panic_boundary, is_close_notify, rslice::NulByte,
-    try_mut_from_ptr, try_mut_slice, try_ref_from_ptr, try_slice, CastPtr,
-    userdata_push, userdata_get,
+    try_mut_from_ptr, try_mut_slice, try_ref_from_ptr, try_slice, userdata_get, userdata_push,
+    CastPtr,
 };
 use rustls_result::NullParameter;
 
@@ -386,8 +386,8 @@ pub extern "C" fn rustls_client_session_set_userdata(
     session: *mut rustls_client_session,
     userdata: *mut c_void,
 ) {
-  let session: &mut Sess = try_mut_from_ptr!(session);
-  session.userdata = userdata;
+    let session: &mut Sess = try_mut_from_ptr!(session);
+    session.userdata = userdata;
 }
 
 #[no_mangle]

--- a/src/client.rs
+++ b/src/client.rs
@@ -204,10 +204,11 @@ impl rustls::ServerCertVerifier for Verifier {
 
 /// Set a custom server certificate verifier.
 ///
-/// The userdata pointer must stay valid until (a) all sessions created with this
-/// config have been freed, and (b) the config itself has been freed.
 /// The callback must not capture any of the pointers in its
 /// rustls_verify_server_cert_params.
+/// If `userdata` has been set with rustls_server_session_set_userdata, it
+/// will be passed to the callback. Otherwise the userdata param passed to
+/// the callback will be NULL.
 ///
 /// The callback must be safe to call on any thread at any time, including
 /// multiple concurrent calls. So, for instance, if the callback mutates
@@ -587,9 +588,9 @@ pub extern "C" fn rustls_client_session_write_tls(
 /// keys and values are highly sensitive data, containing enough information
 /// to break the security of the sessions involved.
 ///
-/// `userdata` must live as long as the config object and any sessions
-/// or other config created from that config object.
-///
+/// If `userdata` has been set with rustls_server_session_set_userdata, it
+/// will be passed to the callbacks. Otherwise the userdata param passed to
+/// the callbacks will be NULL.
 #[no_mangle]
 pub extern "C" fn rustls_client_config_builder_set_persistence(
     builder: *mut rustls_client_config_builder,

--- a/src/client.rs
+++ b/src/client.rs
@@ -59,7 +59,7 @@ pub struct rustls_client_session {
     _private: [u8; 0],
 }
 
-pub struct Sess {
+pub(crate) struct Sess {
     session: ClientSession,
     userdata: *mut c_void,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -209,7 +209,7 @@ impl rustls::ServerCertVerifier for Verifier {
 ///
 /// The callback must not capture any of the pointers in its
 /// rustls_verify_server_cert_params.
-/// If `userdata` has been set with rustls_server_session_set_userdata, it
+/// If `userdata` has been set with rustls_client_session_set_userdata, it
 /// will be passed to the callback. Otherwise the userdata param passed to
 /// the callback will be NULL.
 ///
@@ -598,7 +598,7 @@ pub extern "C" fn rustls_client_session_write_tls(
 /// keys and values are highly sensitive data, containing enough information
 /// to break the security of the sessions involved.
 ///
-/// If `userdata` has been set with rustls_server_session_set_userdata, it
+/// If `userdata` has been set with rustls_client_session_set_userdata, it
 /// will be passed to the callbacks. Otherwise the userdata param passed to
 /// the callbacks will be NULL.
 #[no_mangle]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
-use libc::{c_char, size_t};
-use std::convert::TryInto;
+use libc::{c_char, c_void, size_t};
+use std::{convert::TryInto, ptr::null_mut};
 use std::io::{BufReader, Cursor, Read, Write};
 use std::slice;
 use std::{ffi::CStr, sync::Arc};
@@ -59,8 +59,13 @@ pub struct rustls_client_session {
     _private: [u8; 0],
 }
 
+pub struct Sess {
+    session: ClientSession,
+    userdata: *mut c_void,
+}
+
 impl CastPtr for rustls_client_session {
-    type RustType = ClientSession;
+    type RustType = Sess;
 }
 
 /// Create a rustls_client_config_builder. Caller owns the memory and must
@@ -359,14 +364,16 @@ pub extern "C" fn rustls_client_session_new(
             Ok(nr) => nr,
             Err(webpki::InvalidDNSNameError { .. }) => return rustls_result::InvalidDnsNameError,
         };
-        let client = ClientSession::new(&config, name_ref);
 
         // We've succeeded. Put the client on the heap, and transfer ownership
         // to the caller. After this point, we must return CRUSTLS_OK so the
         // caller knows it is responsible for this memory.
-        let b = Box::new(client);
+        let c = Sess {
+            session: ClientSession::new(&config, name_ref),
+            userdata: null_mut(),
+        };
         unsafe {
-            *session_out = Box::into_raw(b) as *mut _;
+            *session_out = Box::into_raw(Box::new(c)) as *mut _;
         }
 
         return rustls_result::Ok;
@@ -376,16 +383,16 @@ pub extern "C" fn rustls_client_session_new(
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_read(session: *const rustls_client_session) -> bool {
     ffi_panic_boundary! {
-        let session: &ClientSession = try_ref_from_ptr!(session);
-        session.wants_read()
+        let session: &Sess = try_ref_from_ptr!(session);
+        session.session.wants_read()
     }
 }
 
 #[no_mangle]
 pub extern "C" fn rustls_client_session_wants_write(session: *const rustls_client_session) -> bool {
     ffi_panic_boundary! {
-        let session: &ClientSession = try_ref_from_ptr!(session);
-        session.wants_write()
+        let session: &Sess = try_ref_from_ptr!(session);
+        session.session.wants_write()
     }
 }
 
@@ -394,8 +401,8 @@ pub extern "C" fn rustls_client_session_is_handshaking(
     session: *const rustls_client_session,
 ) -> bool {
     ffi_panic_boundary! {
-        let session: &ClientSession = try_ref_from_ptr!(session);
-        session.is_handshaking()
+        let session: &Sess = try_ref_from_ptr!(session);
+        session.session.is_handshaking()
     }
 }
 
@@ -404,8 +411,8 @@ pub extern "C" fn rustls_client_session_process_new_packets(
     session: *mut rustls_client_session,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_mut_from_ptr!(session);
-        match session.process_new_packets() {
+        let session: &mut Sess = try_mut_from_ptr!(session);
+        match session.session.process_new_packets() {
             Ok(()) => rustls_result::Ok,
             Err(e) => return map_error(e),
         }
@@ -417,8 +424,8 @@ pub extern "C" fn rustls_client_session_process_new_packets(
 #[no_mangle]
 pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_client_session) {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_mut_from_ptr!(session);
-        session.send_close_notify()
+        let session: &mut Sess = try_mut_from_ptr!(session);
+        session.session.send_close_notify()
     }
 }
 
@@ -427,7 +434,7 @@ pub extern "C" fn rustls_client_session_send_close_notify(session: *mut rustls_c
 #[no_mangle]
 pub extern "C" fn rustls_client_session_free(session: *mut rustls_client_session) {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_mut_from_ptr!(session);
+        let session: &mut Sess = try_mut_from_ptr!(session);
         // Convert the pointer to a Box and drop it.
         unsafe { Box::from_raw(session); }
     }
@@ -447,7 +454,7 @@ pub extern "C" fn rustls_client_session_write(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_mut_from_ptr!(session);
+        let session: &mut Sess = try_mut_from_ptr!(session);
         let write_buf: &[u8] = try_slice!(buf, count);
         let out_n: &mut size_t = unsafe {
             match out_n.as_mut() {
@@ -455,7 +462,7 @@ pub extern "C" fn rustls_client_session_write(
                 None => return NullParameter,
             }
         };
-        let n_written: usize = match session.write(write_buf) {
+        let n_written: usize = match session.session.write(write_buf) {
             Ok(n) => n,
             Err(_) => return rustls_result::Io,
         };
@@ -485,11 +492,11 @@ pub extern "C" fn rustls_client_session_read(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_mut_from_ptr!(session);
+        let session: &mut Sess = try_mut_from_ptr!(session);
         let read_buf: &mut [u8] = try_mut_slice!(buf, count);
         let out_n: &mut size_t = try_mut_from_ptr!(out_n);
 
-        let n_read: usize = match session.read(read_buf) {
+        let n_read: usize = match session.session.read(read_buf) {
             Ok(n) => n,
             // Rustls turns close_notify alerts into `io::Error` of kind `ConnectionAborted`.
             // https://docs.rs/rustls/0.19.0/rustls/struct.ClientSession.html#impl-Read.
@@ -519,12 +526,12 @@ pub extern "C" fn rustls_client_session_read_tls(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_mut_from_ptr!(session);
+        let session: &mut Sess = try_mut_from_ptr!(session);
         let input_buf: &[u8] = try_slice!(buf, count);
         let out_n: &mut size_t = try_mut_from_ptr!(out_n);
 
         let mut cursor = Cursor::new(input_buf);
-        let n_read: usize = match session.read_tls(&mut cursor) {
+        let n_read: usize = match session.session.read_tls(&mut cursor) {
             Ok(n) => n,
             Err(_) => return rustls_result::Io,
         };
@@ -551,11 +558,11 @@ pub extern "C" fn rustls_client_session_write_tls(
     out_n: *mut size_t,
 ) -> rustls_result {
     ffi_panic_boundary! {
-        let session: &mut ClientSession = try_mut_from_ptr!(session);
+        let session: &mut Sess = try_mut_from_ptr!(session);
         let mut output_buf: &mut [u8] = try_mut_slice!(buf, count);
         let out_n: &mut size_t = try_mut_from_ptr!(out_n);
 
-        let n_written: usize = match session.write_tls(&mut output_buf) {
+        let n_written: usize = match session.session.write_tls(&mut output_buf) {
             Ok(n) => n,
             Err(_) => return rustls_result::Io,
         };

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -519,14 +519,17 @@ void rustls_client_config_free(const struct rustls_client_config *config);
  * If this returns a non-error, the memory pointed to by `session_out` is modified to point
  * at a valid ClientSession. The caller now owns the ClientSession and must call
  * `rustls_client_session_free` when done with it.
- * The userdata pointer points to arbitrary data to be associated with this session
- * for the purpose of callbacks. It may be NULL. If it is non-NULL, the pointed-to
- * data must outlive the session.
  */
 enum rustls_result rustls_client_session_new(const struct rustls_client_config *config,
-                                             void *userdata,
                                              const char *hostname,
                                              struct rustls_client_session **session_out);
+
+/**
+ * Set the userdata pointer associated with this session. This will be passed
+ * to any callbacks invoked by the session, if you've set up callbacks in the config.
+ * The pointed-to data must outlive the session.
+ */
+void rustls_client_session_set_userdata(struct rustls_client_session *session, void *userdata);
 
 bool rustls_client_session_wants_read(const struct rustls_client_session *session);
 
@@ -781,13 +784,16 @@ void rustls_server_config_free(const struct rustls_server_config *config);
  * If this returns a non-error, the memory pointed to by `session_out` is modified to point
  * at a valid ServerSession. The caller now owns the ServerSession and must call
  * `rustls_server_session_free` when done with it.
- * The userdata pointer points to arbitrary data to be associated with this session
- * for the purpose of callbacks. It may be NULL. If it is non-NULL, the pointed-to
- * data must outlive the session.
  */
 enum rustls_result rustls_server_session_new(const struct rustls_server_config *config,
-                                             void *userdata,
                                              struct rustls_server_session **session_out);
+
+/**
+ * Set the userdata pointer associated with this session. This will be passed
+ * to any callbacks invoked by the session, if you've set up callbacks in the config.
+ * The pointed-to data must outlive the session.
+ */
+void rustls_server_session_set_userdata(struct rustls_server_session *session, void *userdata);
 
 bool rustls_server_session_wants_read(const struct rustls_server_session *session);
 

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -481,8 +481,7 @@ const struct rustls_client_config *rustls_client_config_builder_build(struct rus
  * https://docs.rs/rustls/0.19.0/rustls/struct.DangerousClientConfig.html#method.set_certificate_verifier
  */
 void rustls_client_config_builder_dangerous_set_certificate_verifier(struct rustls_client_config_builder *config,
-                                                                     rustls_verify_server_cert_callback callback,
-                                                                     rustls_verify_server_cert_user_data userdata);
+                                                                     rustls_verify_server_cert_callback callback);
 
 /**
  * Add certificates from platform's native root store, using
@@ -520,8 +519,12 @@ void rustls_client_config_free(const struct rustls_client_config *config);
  * If this returns a non-error, the memory pointed to by `session_out` is modified to point
  * at a valid ClientSession. The caller now owns the ClientSession and must call
  * `rustls_client_session_free` when done with it.
+ * The userdata pointer points to arbitrary data to be associated with this session
+ * for the purpose of callbacks. It may be NULL. If it is non-NULL, the pointed-to
+ * data must outlive the session.
  */
 enum rustls_result rustls_client_session_new(const struct rustls_client_config *config,
+                                             void *userdata,
                                              const char *hostname,
                                              struct rustls_client_session **session_out);
 
@@ -621,7 +624,6 @@ enum rustls_result rustls_client_session_write_tls(struct rustls_client_session 
  *
  */
 enum rustls_result rustls_client_config_builder_set_persistence(struct rustls_client_config_builder *builder,
-                                                                rustls_session_store_userdata userdata,
                                                                 rustls_session_store_get_callback get_cb,
                                                                 rustls_session_store_put_callback put_cb);
 
@@ -779,8 +781,12 @@ void rustls_server_config_free(const struct rustls_server_config *config);
  * If this returns a non-error, the memory pointed to by `session_out` is modified to point
  * at a valid ServerSession. The caller now owns the ServerSession and must call
  * `rustls_server_session_free` when done with it.
+ * The userdata pointer points to arbitrary data to be associated with this session
+ * for the purpose of callbacks. It may be NULL. If it is non-NULL, the pointed-to
+ * data must outlive the session.
  */
 enum rustls_result rustls_server_session_new(const struct rustls_server_config *config,
+                                             void *userdata,
                                              struct rustls_server_session **session_out);
 
 bool rustls_server_session_wants_read(const struct rustls_server_session *session);
@@ -912,8 +918,7 @@ const struct rustls_supported_ciphersuite *rustls_server_session_get_negotiated_
  * and vice versa. Same holds true for the set_single_cert variant.
  */
 enum rustls_result rustls_server_config_builder_set_hello_callback(struct rustls_server_config_builder *builder,
-                                                                   rustls_client_hello_callback callback,
-                                                                   rustls_client_hello_userdata userdata);
+                                                                   rustls_client_hello_callback callback);
 
 /**
  * Register callbacks for persistence of TLS session IDs and secrets. Both
@@ -924,7 +929,6 @@ enum rustls_result rustls_server_config_builder_set_hello_callback(struct rustls
  * or other config created from that config object.
  */
 enum rustls_result rustls_server_config_builder_set_persistence(struct rustls_server_config_builder *builder,
-                                                                rustls_session_store_userdata userdata,
                                                                 rustls_session_store_get_callback get_cb,
                                                                 rustls_session_store_put_callback put_cb);
 

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -263,7 +263,7 @@ typedef void *rustls_session_store_userdata;
  * Prototype of a callback that can be installed by the application at the
  * `rustls_server_config` or `rustls_client_config`. This callback will be
  * invoked by a TLS session when looking up the data for a TLS session id.
- * `userdata` will be supplied as provided when registering the callback.
+ * `userdata` will be supplied based on rustls_{client,server}_session_set_userdata.
  *
  * The `buf` points to `count` consecutive bytes where the
  * callback is expected to copy the result to. The number of copied bytes
@@ -292,7 +292,7 @@ typedef enum rustls_result (*rustls_session_store_get_callback)(rustls_session_s
  * `rustls_server_config` or `rustls_client_config`. This callback will be
  * invoked by a TLS session when a TLS session has been created and an id
  * for later use is handed to the client/has been received from the server.
- * `userdata` will be supplied as provided when registering the callback.
+ * `userdata` will be supplied based on rustls_{client,server}_session_set_userdata.
  *
  * The callback should return != 0 to indicate that the value has been
  * successfully persisted in its store.

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -450,7 +450,7 @@ const struct rustls_client_config *rustls_client_config_builder_build(struct rus
  *
  * The callback must not capture any of the pointers in its
  * rustls_verify_server_cert_params.
- * If `userdata` has been set with rustls_server_session_set_userdata, it
+ * If `userdata` has been set with rustls_client_session_set_userdata, it
  * will be passed to the callback. Otherwise the userdata param passed to
  * the callback will be NULL.
  *
@@ -621,7 +621,7 @@ enum rustls_result rustls_client_session_write_tls(struct rustls_client_session 
  * keys and values are highly sensitive data, containing enough information
  * to break the security of the sessions involved.
  *
- * If `userdata` has been set with rustls_server_session_set_userdata, it
+ * If `userdata` has been set with rustls_client_session_set_userdata, it
  * will be passed to the callbacks. Otherwise the userdata param passed to
  * the callbacks will be NULL.
  */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 #![allow(non_camel_case_types)]
 use libc::{c_char, c_void, size_t};
 use std::cell::RefCell;
-use std::ptr::null_mut;
 use std::cmp::min;
 use std::io::ErrorKind::ConnectionAborted;
+use std::ptr::null_mut;
 use std::sync::Arc;
 use std::{io, mem, slice};
 
@@ -28,28 +28,34 @@ pub struct UserdataError();
 
 impl Drop for UserdataGuard {
     fn drop(&mut self) {
-        USERDATA.try_with(|userdata| {
-            if let Ok(mut v) = userdata.try_borrow_mut() {
-                v.pop();
-            }
-        }).ok();
+        USERDATA
+            .try_with(|userdata| {
+                if let Ok(mut v) = userdata.try_borrow_mut() {
+                    v.pop();
+                }
+            })
+            .ok();
     }
 }
 
 #[must_use = "If you drop the guard, userdata will be immediately cleared"]
 pub fn userdata_push(u: *mut c_void) -> Result<UserdataGuard, UserdataError> {
-    USERDATA.try_with(|userdata| match userdata.try_borrow_mut() {
-        Ok(mut v) => v.push(u),
-        _ => (),
-    }).map_err(|_| UserdataError())?;
+    USERDATA
+        .try_with(|userdata| match userdata.try_borrow_mut() {
+            Ok(mut v) => v.push(u),
+            _ => (),
+        })
+        .map_err(|_| UserdataError())?;
     Ok(UserdataGuard())
 }
 
 pub fn userdata_get() -> *mut c_void {
-    USERDATA.try_with(|userdata| match userdata.try_borrow_mut() {
-        Ok(v) => *v.last().unwrap_or(&null_mut()),
-        _ => null_mut(),
-    }).unwrap_or(null_mut())
+    USERDATA
+        .try_with(|userdata| match userdata.try_borrow_mut() {
+            Ok(v) => *v.last().unwrap_or(&null_mut()),
+            _ => null_mut(),
+        })
+        .unwrap_or(null_mut())
 }
 
 // Keep in sync with Cargo.toml.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,9 @@
 #![allow(non_camel_case_types)]
 use libc::{c_char, c_void, size_t};
 use std::cell::RefCell;
-use std::cmp::min;
 use std::io::ErrorKind::ConnectionAborted;
-use std::ptr::null_mut;
 use std::sync::Arc;
+use std::{cmp::min, thread::AccessError};
 use std::{io, mem, slice};
 
 mod cipher;
@@ -35,39 +34,210 @@ thread_local! {
 
 /// UserdataGuard pops an entry off the USERDATA stack, restoring the
 /// thread-local state to its value previous to the creation of the UserdataGuard.
-pub struct UserdataGuard();
-pub struct UserdataError();
+/// Invariants: As long as a UserdataGuard is live:
+//// - The stack of userdata items for this thread must have at least one item.
+///  - The top item on that stack must be the one this guard was built with.
+///  - The `data` field must not be None.
+/// If any of these invariants fails, try_drop will return an error.
+pub struct UserdataGuard {
+    // Keep a copy of the data we expect to be popping off the stack. This allows
+    // us to check for consistency, and also serves to make this type !Send:
+    // https://doc.rust-lang.org/nightly/std/primitive.pointer.html#impl-Send-1
+    data: Option<*mut c_void>,
+}
+
+impl UserdataGuard {
+    fn new(u: *mut c_void) -> Self {
+        UserdataGuard { data: Some(u) }
+    }
+
+    /// Even though we have a Drop impl on this guard, when possible it's
+    /// best to call try_drop explicitly. That way any failures of internal
+    /// variants can be signaled to the user immediately by returning
+    /// rustls_result::Panic.
+    fn try_drop(mut self) -> Result<(), UserdataError> {
+        self.try_pop()
+    }
+
+    fn try_pop(&mut self) -> Result<(), UserdataError> {
+        let expected_data = match self.data {
+            Some(d) => d,
+            None => return Err(UserdataError::AlreadyPopped),
+        };
+        eprintln!("popping");
+        USERDATA
+            .try_with(|userdata| {
+                userdata.try_borrow_mut().map_or_else(
+                    |_| Err(UserdataError::AlreadyBorrowed),
+                    |mut v| match v.pop() {
+                        Some(u) => {
+                            self.data = None;
+                            if u == expected_data {
+                                Ok(())
+                            } else {
+                                Err(UserdataError::WrongData)
+                            }
+                        }
+                        None => Err(UserdataError::EmptyStack),
+                    },
+                )
+            })
+            .unwrap_or_else(|_: AccessError| Err(UserdataError::AccessError))
+    }
+}
 
 impl Drop for UserdataGuard {
     fn drop(&mut self) {
-        USERDATA
-            .try_with(|userdata| {
-                if let Ok(mut v) = userdata.try_borrow_mut() {
-                    v.pop();
-                }
-            })
-            .ok();
+        self.try_pop().ok();
     }
+}
+
+#[derive(Debug)]
+pub enum UserdataError {
+    /// try_pop was called twice.
+    AlreadyPopped,
+    /// The RefCell is borrowed somewhere else.
+    AlreadyBorrowed,
+    /// The stack of userdata items was already empty.
+    EmptyStack,
+    /// The LocalKey was destroyed before this call.
+    /// See https://doc.rust-lang.org/std/thread/struct.LocalKey.html#method.try_with
+    AccessError,
+    /// Unexpected pointer when popping.
+    WrongData,
 }
 
 #[must_use = "If you drop the guard, userdata will be immediately cleared"]
 pub fn userdata_push(u: *mut c_void) -> Result<UserdataGuard, UserdataError> {
     USERDATA
-        .try_with(|userdata| match userdata.try_borrow_mut() {
-            Ok(mut v) => v.push(u),
-            _ => (),
+        .try_with(|userdata| {
+            userdata.try_borrow_mut().map_or_else(
+                |_| Err(UserdataError::AlreadyBorrowed),
+                |mut v| {
+                    v.push(u);
+                    Ok(())
+                },
+            )
         })
-        .map_err(|_| UserdataError())?;
-    Ok(UserdataGuard())
+        .unwrap_or(Err(UserdataError::AccessError))?;
+    Ok(UserdataGuard::new(u))
 }
 
-pub fn userdata_get() -> *mut c_void {
+pub fn userdata_get() -> Result<*mut c_void, UserdataError> {
     USERDATA
-        .try_with(|userdata| match userdata.try_borrow_mut() {
-            Ok(v) => *v.last().unwrap_or(&null_mut()),
-            _ => null_mut(),
+        .try_with(|userdata| {
+            userdata.try_borrow_mut().map_or_else(
+                |_| Err(UserdataError::AlreadyBorrowed),
+                |v| match v.last() {
+                    Some(u) => Ok(*u),
+                    None => Err(UserdataError::EmptyStack),
+                },
+            )
         })
-        .unwrap_or(null_mut())
+        .unwrap_or(Err(UserdataError::AccessError))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn guard_try_pop() {
+        let data = "hello";
+        let data_ptr: *mut c_void = data as *const _ as _;
+        let mut guard = userdata_push(data_ptr).unwrap();
+        assert_eq!(userdata_get().unwrap(), data_ptr);
+        guard.try_pop().unwrap();
+        assert!(matches!(guard.try_pop(), Err(_)));
+    }
+
+    #[test]
+    fn guard_try_drop() {
+        let data = "hello";
+        let data_ptr: *mut c_void = data as *const _ as _;
+        let guard = userdata_push(data_ptr).unwrap();
+        assert_eq!(userdata_get().unwrap(), data_ptr);
+        guard.try_drop().unwrap();
+        assert!(matches!(userdata_get(), Err(_)));
+    }
+
+    #[test]
+    fn guard_drop() {
+        let data = "hello";
+        let data_ptr: *mut c_void = data as *const _ as _;
+        {
+            let _guard = userdata_push(data_ptr).unwrap();
+            assert_eq!(userdata_get().unwrap(), data_ptr);
+        }
+        assert!(matches!(userdata_get(), Err(_)));
+    }
+
+    #[test]
+    fn nested_guards() {
+        let hello = "hello";
+        let hello_ptr: *mut c_void = hello as *const _ as _;
+        {
+            let guard = userdata_push(hello_ptr).unwrap();
+            assert_eq!(userdata_get().unwrap(), hello_ptr);
+            {
+                let yo = "yo";
+                let yo_ptr: *mut c_void = yo as *const _ as _;
+                let guard2 = userdata_push(yo_ptr).unwrap();
+                assert_eq!(userdata_get().unwrap(), yo_ptr);
+                guard2.try_drop().unwrap();
+            }
+            assert_eq!(userdata_get().unwrap(), hello_ptr);
+            guard.try_drop().unwrap();
+        }
+        assert!(matches!(userdata_get(), Err(_)));
+    }
+
+    #[test]
+    fn out_of_order_drop() {
+        let hello = "hello";
+        let hello_ptr: *mut c_void = hello as *const _ as _;
+        let guard = userdata_push(hello_ptr).unwrap();
+        assert_eq!(userdata_get().unwrap(), hello_ptr);
+
+        let yo = "yo";
+        let yo_ptr: *mut c_void = yo as *const _ as _;
+        let guard2 = userdata_push(yo_ptr).unwrap();
+        assert_eq!(userdata_get().unwrap(), yo_ptr);
+
+        assert!(matches!(guard.try_drop(), Err(UserdataError::WrongData)));
+        assert!(matches!(guard2.try_drop(), Err(UserdataError::WrongData)));
+    }
+
+    #[test]
+    fn userdata_multi_threads() {
+        let hello = "hello";
+        let hello_ptr: *mut c_void = hello as *const _ as _;
+        let guard = userdata_push(hello_ptr).unwrap();
+        assert_eq!(userdata_get().unwrap(), hello_ptr);
+
+        let thread1 = thread::spawn(|| {
+            let yo = "hello";
+            let yo_ptr: *mut c_void = yo as *const _ as _;
+            let guard2 = userdata_push(yo_ptr).unwrap();
+            assert_eq!(userdata_get().unwrap(), yo_ptr);
+
+            let greetz = "greetz";
+            let greetz_ptr: *mut c_void = greetz as *const _ as _;
+
+            let guard3 = userdata_push(greetz_ptr).unwrap();
+
+            assert_eq!(userdata_get().unwrap(), greetz_ptr);
+            guard3.try_drop().unwrap();
+
+            assert_eq!(userdata_get().unwrap(), yo_ptr);
+            guard2.try_drop().unwrap();
+        });
+
+        assert_eq!(userdata_get().unwrap(), hello_ptr);
+        guard.try_drop().unwrap();
+        thread1.join().unwrap();
+    }
 }
 
 // Keep in sync with Cargo.toml.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ mod tests {
         assert_eq!(userdata_get().unwrap(), hello_ptr);
 
         let thread1 = thread::spawn(|| {
-            let yo = "hello";
+            let yo = "yo";
             let yo_ptr: *mut c_void = yo as *const _ as _;
             let guard2 = userdata_push(yo_ptr).unwrap();
             assert_eq!(userdata_get().unwrap(), yo_ptr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ impl Drop for UserdataGuard {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum UserdataError {
     /// try_pop was called twice.
     AlreadyPopped,

--- a/src/main.c
+++ b/src/main.c
@@ -463,7 +463,7 @@ do_request(const struct rustls_client_config *client_config,
   }
 
   rustls_result result =
-    rustls_client_session_new(client_config, hostname, &client_session);
+    rustls_client_session_new(client_config, "verify arg", hostname, &client_session);
   if(result != RUSTLS_RESULT_OK) {
     print_error("client_session_new", result);
     goto cleanup;
@@ -542,8 +542,7 @@ main(int argc, const char **argv)
   }
 
   if(getenv("NO_CHECK_CERTIFICATE")) {
-    rustls_client_config_builder_dangerous_set_certificate_verifier(config_builder, verify,
-      "verify_arg");
+    rustls_client_config_builder_dangerous_set_certificate_verifier(config_builder, verify);
   }
 
   client_config = rustls_client_config_builder_build(config_builder);

--- a/src/main.c
+++ b/src/main.c
@@ -463,11 +463,13 @@ do_request(const struct rustls_client_config *client_config,
   }
 
   rustls_result result =
-    rustls_client_session_new(client_config, "verify arg", hostname, &client_session);
+    rustls_client_session_new(client_config, hostname, &client_session);
   if(result != RUSTLS_RESULT_OK) {
     print_error("client_session_new", result);
     goto cleanup;
   }
+
+  rustls_client_session_set_userdata(client_session, "verify arg");
 
   ret = send_request_and_read_response(sockfd, client_session, hostname, path);
   if(ret != RUSTLS_RESULT_OK) {

--- a/src/main.c
+++ b/src/main.c
@@ -469,7 +469,7 @@ do_request(const struct rustls_client_config *client_config,
     goto cleanup;
   }
 
-  rustls_client_session_set_userdata(client_session, "verify arg");
+  rustls_client_session_set_userdata(client_session, "verify_arg");
 
   ret = send_request_and_read_response(sockfd, client_session, hostname, path);
   if(ret != RUSTLS_RESULT_OK) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,7 +59,7 @@ pub struct rustls_server_session {
     _private: [u8; 0],
 }
 
-pub struct Sess {
+pub(crate) struct Sess {
     session: ServerSession,
     userdata: *mut c_void,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,9 @@
 use libc::size_t;
-use std::{ffi::c_void, ptr::null_mut};
 use std::io::{Cursor, Read, Write};
 use std::slice;
 use std::sync::Arc;
 use std::{convert::TryInto, ptr::null};
+use std::{ffi::c_void, ptr::null_mut};
 
 use rustls::{sign::CertifiedKey, SupportedCipherSuite};
 use rustls::{ClientHello, NoClientAuth, ServerConfig, ServerSession, Session};
@@ -15,12 +15,12 @@ use crate::enums::rustls_tls_version_from_u16;
 use crate::error::{map_error, rustls_result};
 use crate::rslice::{rustls_slice_bytes, rustls_slice_slice_bytes, rustls_slice_u16, rustls_str};
 use crate::session::{
-    rustls_session_store_get_callback, rustls_session_store_put_callback,
-    SessionStoreBroker, SessionStoreGetCallback, SessionStorePutCallback,
+    rustls_session_store_get_callback, rustls_session_store_put_callback, SessionStoreBroker,
+    SessionStoreGetCallback, SessionStorePutCallback,
 };
 use crate::{
     arc_with_incref_from_raw, ffi_panic_boundary, is_close_notify, try_mut_from_ptr, try_mut_slice,
-    try_ref_from_ptr, try_slice, CastPtr, userdata_push, userdata_get,
+    try_ref_from_ptr, try_slice, userdata_get, userdata_push, CastPtr,
 };
 
 /// A server config being constructed. A builder can be modified by,
@@ -321,8 +321,8 @@ pub extern "C" fn rustls_server_session_set_userdata(
     session: *mut rustls_server_session,
     userdata: *mut c_void,
 ) {
-  let session: &mut Sess = try_mut_from_ptr!(session);
-  session.userdata = userdata;
+    let session: &mut Sess = try_mut_from_ptr!(session);
+    session.userdata = userdata;
 }
 
 #[no_mangle]
@@ -673,9 +673,7 @@ struct ClientHelloResolver {
 }
 
 impl ClientHelloResolver {
-    pub fn new(
-        callback: ClientHelloCallback,
-    ) -> ClientHelloResolver {
+    pub fn new(callback: ClientHelloCallback) -> ClientHelloResolver {
         ClientHelloResolver { callback }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,7 +9,7 @@ pub type rustls_session_store_userdata = *mut c_void;
 /// Prototype of a callback that can be installed by the application at the
 /// `rustls_server_config` or `rustls_client_config`. This callback will be
 /// invoked by a TLS session when looking up the data for a TLS session id.
-/// `userdata` will be supplied as provided when registering the callback.
+/// `userdata` will be supplied based on rustls_{client,server}_session_set_userdata.
 ///
 /// The `buf` points to `count` consecutive bytes where the
 /// callback is expected to copy the result to. The number of copied bytes
@@ -54,7 +54,7 @@ pub(crate) type SessionStoreGetCallback = unsafe extern "C" fn(
 /// `rustls_server_config` or `rustls_client_config`. This callback will be
 /// invoked by a TLS session when a TLS session has been created and an id
 /// for later use is handed to the client/has been received from the server.
-/// `userdata` will be supplied as provided when registering the callback.
+/// `userdata` will be supplied based on rustls_{client,server}_session_set_userdata.
 ///
 /// The callback should return != 0 to indicate that the value has been
 /// successfully persisted in its store.

--- a/src/session.rs
+++ b/src/session.rs
@@ -89,10 +89,7 @@ impl SessionStoreBroker {
 
     fn retrieve(&self, key: &[u8], remove: bool) -> Option<Vec<u8>> {
         let key: rustls_slice_bytes = key.into();
-        let userdata = match userdata_get() {
-            Ok(u) => u,
-            Err(_) => return None,
-        };
+        let userdata = userdata_get().ok()?;
         // This is excessive in size, but the returned data in rustls is
         // only read once and then dropped.
         // See <https://github.com/abetterinternet/crustls/pull/64#issuecomment-800766940>

--- a/src/session.rs
+++ b/src/session.rs
@@ -83,14 +83,8 @@ pub(crate) struct SessionStoreBroker {
 }
 
 impl SessionStoreBroker {
-    pub fn new(
-        get_cb: SessionStoreGetCallback,
-        put_cb: SessionStorePutCallback,
-    ) -> Self {
-        SessionStoreBroker {
-            get_cb,
-            put_cb,
-        }
+    pub fn new(get_cb: SessionStoreGetCallback, put_cb: SessionStorePutCallback) -> Self {
+        SessionStoreBroker { get_cb, put_cb }
     }
 
     fn retrieve(&self, key: &[u8], remove: bool) -> Option<Vec<u8>> {


### PR DESCRIPTION
Use thread-local storage to make the userdata available to callbacks. This relies on the fact that rustls always does work on the thread it was called from (https://github.com/abetterinternet/mod_tls/issues/2#issuecomment-800495123).

The per-session userdata pointer is set with `rustls_*_session_set_userdata`. In process_new_packets, we push the current session's userdata pointer onto a thread-local stack, and build a guard object that will later pop it off. In our traits that call out to callbacks, we read the most recent value from the stack, and pass that as userdata. The stack makes it possible for callbacks to invoke process_new_packets themselves (for instance, if a crustls server is working with a client in a callback).

First commit is the boring renaming stuff (thanks for the suggestion @djc), subsequent commits are more interesting. @icing can you give this a try and see if it meets your needs?

Follow-up to #83
Fixes #81