### PR TITLE
Store peer certificates on Connection instance

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -31,6 +31,26 @@ pub struct rustls_certificate {
 impl CastPtr for rustls_certificate {
     type RustType = Certificate;
 }
+
+/// Get the DER data of the certificate itself.
+/// The data is owned by the certificate and has the same lifetime.
+#[no_mangle]
+pub extern "C" fn rustls_certificate_get_der(
+    cert: *const rustls_certificate,
+    out_der_data: *mut *const u8,
+    out_der_len: *mut size_t,
+) -> rustls_result {
+    ffi_panic_boundary! {
+        let cert = try_ref_from_ptr!(cert);
+        let out_der_data: &mut *const u8 = try_mut_from_ptr!(out_der_data);
+        let out_der_len: &mut size_t = try_mut_from_ptr!(out_der_len);
+        let der = cert.as_ref();
+        *out_der_data = der.as_ptr();
+        *out_der_len = der.len();
+        rustls_result::Ok
+    }
+}
+
 /// The complete chain of certificates to send during a TLS handshake,
 /// plus a private key that matches the end-entity (leaf) certificate.
 /// Corresponds to `CertifiedKey` in the Rust API.

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -443,6 +443,14 @@ typedef const struct rustls_certified_key *(*rustls_client_hello_callback)(rustl
 size_t rustls_version(char *buf, size_t len);
 
 /**
+ * Get the DER data of the certificate itself.
+ * The data is owned by the certificate and has the same lifetime.
+ */
+enum rustls_result rustls_certificate_get_der(const struct rustls_certificate *cert,
+                                              const uint8_t **out_der_data,
+                                              size_t *out_der_len);
+
+/**
  * Return a 16-bit unsigned integer corresponding to this cipher suite's assignment from
  * <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>.
  * The bytes from the assignment are interpreted in network order.
@@ -779,7 +787,7 @@ void rustls_connection_send_close_notify(struct rustls_connection *conn);
  * in the chain. Requesting an index higher than what is available returns
  * NULL.
  */
-const struct rustls_certificate *rustls_connection_get_peer_certificate(const struct rustls_connection *conn,
+const struct rustls_certificate *rustls_connection_get_peer_certificate(struct rustls_connection *conn,
                                                                         size_t i);
 
 /**


### PR DESCRIPTION
This fixes a use-after-free (#101) that would happen in any code using rustls_connection_get_peer_certificate.

Also, add rustls_certificate_get_der.