### PR TITLE
Add logging support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ libc = "0.2"
 rustls-native-certs = "0.5.0"
 sct = "0.6.0"
 rustls-pemfile = "0.2.0"
+log = "0.4.14"
 
 [dev_dependencies]
 cbindgen = "*"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ target/crustls-demo: target/main.o target/$(PROFILE)/libcrustls.a
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 target/$(PROFILE)/libcrustls.a: src/*.rs Cargo.toml
-	cargo build $(CARGOFLAGS)
+	RUSTFLAGS="-C metadata=rustls-ffi" cargo build $(CARGOFLAGS)
 
 target/main.o: src/main.c src/crustls.h | target
 	$(CC) -o $@ -c $< $(CFLAGS)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -118,8 +118,11 @@ pub extern "C" fn rustls_connection_set_userdata(
     conn.userdata = userdata;
 }
 
+/// Set the logging callback for this connection. The log callback will be invoked
+/// with the userdata parameter previously set by rustls_connection_set_userdata, or
+/// NULL if no userdata was set.
 #[no_mangle]
-pub extern "C" fn rustls_client_connection_set_log_callback(
+pub extern "C" fn rustls_connection_set_log_callback(
     conn: *mut rustls_connection,
     cb: rustls_log_callback,
 ) {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -6,6 +6,7 @@ use rustls::{Certificate, ClientSession, ServerSession, Session, SupportedCipher
 
 use crate::io::{CallbackReader, CallbackWriter, ReadCallback, WriteCallback};
 use crate::is_close_notify;
+use crate::log::{ensure_log_registered, rustls_log_callback};
 use crate::{
     cipher::{rustls_certificate, rustls_supported_ciphersuite},
     error::{map_error, rustls_io_result, rustls_result},
@@ -19,6 +20,7 @@ use rustls_result::NullParameter;
 pub(crate) struct Connection {
     conn: Inner,
     userdata: *mut c_void,
+    log_callback: rustls_log_callback,
     peer_certs: Option<Vec<Certificate>>,
 }
 
@@ -32,6 +34,7 @@ impl Connection {
         Connection {
             conn: Inner::Client(s),
             userdata: null_mut(),
+            log_callback: None,
             peer_certs: None,
         }
     }
@@ -40,6 +43,7 @@ impl Connection {
         Connection {
             conn: Inner::Server(s),
             userdata: null_mut(),
+            log_callback: None,
             peer_certs: None,
         }
     }
@@ -114,6 +118,16 @@ pub extern "C" fn rustls_connection_set_userdata(
     conn.userdata = userdata;
 }
 
+#[no_mangle]
+pub extern "C" fn rustls_client_connection_set_log_callback(
+    conn: *mut rustls_connection,
+    cb: rustls_log_callback,
+) {
+    let conn: &mut Connection = try_mut_from_ptr!(conn);
+    ensure_log_registered();
+    conn.log_callback = cb;
+}
+
 /// Read some TLS bytes from the network into internal buffers. The actual network
 /// I/O is performed by `callback`, which you provide. Rustls will invoke your
 /// callback with a suitable buffer to store the read bytes into. You don't have
@@ -186,7 +200,7 @@ pub extern "C" fn rustls_connection_process_new_packets(
 ) -> rustls_result {
     ffi_panic_boundary! {
         let conn: &mut Connection = try_mut_from_ptr!(conn);
-        let guard = match userdata_push(conn.userdata) {
+        let guard = match userdata_push(conn.userdata, conn.log_callback) {
             Ok(g) => g,
             Err(_) => return rustls_result::Panic,
         };

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -330,6 +330,12 @@ typedef enum rustls_result (*rustls_session_store_get_callback)(rustls_session_s
  */
 typedef enum rustls_result (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
 
+typedef struct rustls_log_params {
+  struct rustls_str message;
+} rustls_log_params;
+
+typedef void (*rustls_log_callback)(void *userdata, const struct rustls_log_params *params);
+
 /**
  * A return value for a function that may return either success (0) or a
  * non-zero value representing an error.
@@ -723,6 +729,9 @@ enum rustls_result rustls_client_config_builder_set_persistence(struct rustls_cl
  * The pointed-to data must outlive the connection.
  */
 void rustls_connection_set_userdata(struct rustls_connection *conn, void *userdata);
+
+void rustls_client_connection_set_log_callback(struct rustls_connection *conn,
+                                               rustls_log_callback cb);
 
 /**
  * Read some TLS bytes from the network into internal buffers. The actual network

--- a/src/crustls.h
+++ b/src/crustls.h
@@ -330,7 +330,10 @@ typedef enum rustls_result (*rustls_session_store_get_callback)(rustls_session_s
  */
 typedef enum rustls_result (*rustls_session_store_put_callback)(rustls_session_store_userdata userdata, const struct rustls_slice_bytes *key, const struct rustls_slice_bytes *val);
 
+typedef size_t rustls_log_level;
+
 typedef struct rustls_log_params {
+  rustls_log_level level;
   struct rustls_str message;
 } rustls_log_params;
 
@@ -730,8 +733,12 @@ enum rustls_result rustls_client_config_builder_set_persistence(struct rustls_cl
  */
 void rustls_connection_set_userdata(struct rustls_connection *conn, void *userdata);
 
-void rustls_client_connection_set_log_callback(struct rustls_connection *conn,
-                                               rustls_log_callback cb);
+/**
+ * Set the logging callback for this connection. The log callback will be invoked
+ * with the userdata parameter previously set by rustls_connection_set_userdata, or
+ * NULL if no userdata was set.
+ */
+void rustls_connection_set_log_callback(struct rustls_connection *conn, rustls_log_callback cb);
 
 /**
  * Read some TLS bytes from the network into internal buffers. The actual network
@@ -873,6 +880,11 @@ void rustls_connection_free(struct rustls_connection *conn);
 void rustls_error(enum rustls_result result, char *buf, size_t len, size_t *out_n);
 
 bool rustls_result_is_cert_error(enum rustls_result result);
+
+/**
+ * Return a rustls_str containing the stringified version of a log level.
+ */
+struct rustls_str rustls_log_level_str(rustls_log_level level);
 
 /**
  * Return the length of the outer slice. If the input pointer is NULL,

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,38 @@
+use std::convert::TryInto;
+
+use libc::c_void;
+
+use crate::{log_callback_get, rslice::rustls_str};
+
+struct Logger {}
+
+impl log::Log for Logger {
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record<'_>) {
+        if let Ok((Some(cb), userdata)) = log_callback_get() {
+            let message = format!("{} {} {}", record.target(), record.level(), record.args());
+            if let Ok(message) = message.as_str().try_into() {
+                unsafe {
+                    cb(userdata, &rustls_log_params { message });
+                }
+            }
+        }
+    }
+    fn flush(&self) {}
+}
+
+pub(crate) fn ensure_log_registered() {
+    log::set_logger(&Logger {}).ok();
+    log::set_max_level(log::LevelFilter::Debug)
+}
+
+#[repr(C)]
+pub struct rustls_log_params<'a> {
+    message: rustls_str<'a>,
+}
+
+#[allow(non_camel_case_types)]
+pub type rustls_log_callback =
+    Option<unsafe extern "C" fn(userdata: *mut c_void, params: *const rustls_log_params)>;

--- a/src/main.c
+++ b/src/main.c
@@ -414,6 +414,14 @@ cleanup:
   return ret;
 }
 
+void
+log_cb(void *userdata, const struct rustls_log_params *params)
+{
+  struct demo_conn *conn = (struct demo_conn*)userdata;
+  fprintf(stderr, "rustls[fd %d]: %.*s\n", conn->fd,
+    (int)params->message.len, params->message.data);
+}
+
 int
 do_request(const struct rustls_client_config *client_config,
            const char *hostname, const char *path)
@@ -442,6 +450,7 @@ do_request(const struct rustls_client_config *client_config,
   }
 
   rustls_connection_set_userdata(client_conn, conn);
+  rustls_client_connection_set_log_callback(client_conn, log_cb);
 
   ret = send_request_and_read_response(conn, client_conn, hostname, path);
   if(ret != RUSTLS_RESULT_OK) {

--- a/src/main.c
+++ b/src/main.c
@@ -418,8 +418,9 @@ void
 log_cb(void *userdata, const struct rustls_log_params *params)
 {
   struct demo_conn *conn = (struct demo_conn*)userdata;
-  fprintf(stderr, "rustls[fd %d]: %.*s\n", conn->fd,
-    (int)params->message.len, params->message.data);
+  struct rustls_str level_str = rustls_log_level_str(params->level);
+  fprintf(stderr, "rustls[fd %d][%.*s]: %.*s\n", conn->fd,
+    (int)level_str.len, level_str.data, (int)params->message.len, params->message.data);
 }
 
 int
@@ -450,7 +451,7 @@ do_request(const struct rustls_client_config *client_config,
   }
 
   rustls_connection_set_userdata(client_conn, conn);
-  rustls_client_connection_set_log_callback(client_conn, log_cb);
+  rustls_connection_set_log_callback(client_conn, log_cb);
 
   ret = send_request_and_read_response(conn, client_conn, hostname, path);
   if(ret != RUSTLS_RESULT_OK) {

--- a/src/rslice.rs
+++ b/src/rslice.rs
@@ -163,6 +163,16 @@ impl<'a> TryFrom<&'a str> for rustls_str<'a> {
     }
 }
 
+impl<'a> rustls_str<'a> {
+    pub fn from_str_unchecked(s: &'static str) -> rustls_str<'static> {
+        rustls_str {
+            data: s.as_ptr() as *const _,
+            len: s.len(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 #[test]
 fn test_rustls_str() {
     let s = "abcd";


### PR DESCRIPTION
This uses name mangling to ensure we get our own isolated copy of the `log` crate, so we are free to set our own logger. The technique is described at https://github.com/jsha/rust-private-loggers.

That logger will be set each time rustls_connection_set_log_callback is called. Every time after the first, we will fail to register a log (but will ignore the error because we already registered one, and our log instances are all identical).

Our log implementation uses the same thread-local userdata values we use for callbacks that implement customizable traits in rustls. The thread-local storage now includes a log_callback parameter as well as a userdata parameter.

Still a draft because:

 - I'd like to think about exporting the [`Level`](https://docs.rs/log/0.4.14/log/enum.Level.html) enum from `log` so users can dispatch logs to different places by level.